### PR TITLE
Add Type and Timestamp to ClipboardEvent struct

### DIFF
--- a/sdl/sdl_events.go
+++ b/sdl/sdl_events.go
@@ -310,7 +310,10 @@ type OSEvent struct {
 	Timestamp uint32
 }
 
-type ClipboardEvent struct {}
+type ClipboardEvent struct {
+	Type uint32
+	Timestamp uint32
+}
 
 type UserEvent struct {
 	Type uint32


### PR DESCRIPTION
I overlooked that all the other events had type and timestamp values. (Still not sure if any of the other data the comes with ClipboardEvent is useful)
