### PR TITLE
go fmt everywhere, all calls to C.CString are followed by a defer C.free

### DIFF
--- a/sdl/sdl.go
+++ b/sdl/sdl.go
@@ -5,20 +5,25 @@ package sdl
 import "C"
 
 const (
-	INIT_TIMER			= 0x00000001
-	INIT_AUDIO			= 0x00000010
-	INIT_VIDEO			= 0x00000020
-	INIT_JOYSTICK			= 0x00000200
-	INIT_HAPTIC			= 0x00001000
-	INIT_GAMECONTROLLER		= 0x00002000
-	INIT_NOPARACHUTE		= 0x00100000
-	INIT_EVERYTHING			= INIT_TIMER | INIT_AUDIO | INIT_VIDEO | INIT_JOYSTICK |
-					  INIT_HAPTIC | INIT_GAMECONTROLLER
+	INIT_TIMER          = 0x00000001
+	INIT_AUDIO          = 0x00000010
+	INIT_VIDEO          = 0x00000020
+	INIT_JOYSTICK       = 0x00000200
+	INIT_HAPTIC         = 0x00001000
+	INIT_GAMECONTROLLER = 0x00002000
+	INIT_NOPARACHUTE    = 0x00100000
+	INIT_EVERYTHING     = INIT_TIMER | INIT_AUDIO | INIT_VIDEO | INIT_JOYSTICK |
+		INIT_HAPTIC | INIT_GAMECONTROLLER
+)
+
+const (
+	RELEASED = 0
+	PRESSED  = 1
 )
 
 func Init(flags uint32) int {
-	_flags := (C.Uint32) (flags)
-	return (int) (C.SDL_Init(_flags))
+	_flags := (C.Uint32)(flags)
+	return (int)(C.SDL_Init(_flags))
 }
 
 func Quit() {
@@ -26,20 +31,20 @@ func Quit() {
 }
 
 func InitSubSystem(flags uint32) int {
-	_flags := (C.Uint32) (flags)
-	return (int) (C.SDL_InitSubSystem(_flags))
+	_flags := (C.Uint32)(flags)
+	return (int)(C.SDL_InitSubSystem(_flags))
 }
 
 func QuitSubSystem(flags uint32) {
-	_flags := (C.Uint32) (flags)
+	_flags := (C.Uint32)(flags)
 	C.SDL_QuitSubSystem(_flags)
 }
 
 func WasInit(flags uint32) uint32 {
-	_flags := (C.Uint32) (flags)
-	return (uint32) (C.SDL_WasInit(_flags))
+	_flags := (C.Uint32)(flags)
+	return (uint32)(C.SDL_WasInit(_flags))
 }
 
 func GetPlatform() string {
-	return (string) (C.GoString(C.SDL_GetPlatform()))
+	return (string)(C.GoString(C.SDL_GetPlatform()))
 }

--- a/sdl/sdl_audio.go
+++ b/sdl/sdl_audio.go
@@ -7,53 +7,53 @@ import "C"
 import "unsafe"
 
 const (
-	AUDIO_MASK_BITSIZE       = 0xFF
-	AUDIO_MASK_DATATYPE      = 1 << 8
-	AUDIO_MASK_ENDIAN        = 1 << 12
-	AUDIO_MASK_SIGNED        = 1 << 15
+	AUDIO_MASK_BITSIZE  = 0xFF
+	AUDIO_MASK_DATATYPE = 1 << 8
+	AUDIO_MASK_ENDIAN   = 1 << 12
+	AUDIO_MASK_SIGNED   = 1 << 15
 )
 
 const (
-	AUDIO_U8		 = 0x0008
-	AUDIO_S8		 = 0x8008
-	AUDIO_U16LSB		 = 0x0010
-	AUDIO_S16LSB		 = 0x8010
-	AUDIO_U16MSB		 = 0x1010
-	AUDIO_S16MSB		 = 0x9010
-	AUDIO_U16		 = AUDIO_U16LSB
-	AUDIO_S16		 = AUDIO_S16LSB
+	AUDIO_U8     = 0x0008
+	AUDIO_S8     = 0x8008
+	AUDIO_U16LSB = 0x0010
+	AUDIO_S16LSB = 0x8010
+	AUDIO_U16MSB = 0x1010
+	AUDIO_S16MSB = 0x9010
+	AUDIO_U16    = AUDIO_U16LSB
+	AUDIO_S16    = AUDIO_S16LSB
 )
 
 const (
-	AUDIO_S32LSB		 = 0x8020
-	AUDIO_S32MSB		 = 0x9020
-	AUDIO_S32		 = AUDIO_S32LSB
+	AUDIO_S32LSB = 0x8020
+	AUDIO_S32MSB = 0x9020
+	AUDIO_S32    = AUDIO_S32LSB
 )
 
 const (
-	AUDIO_F32LSB		 = 0x8120
-	AUDIO_F32MSB		 = 0x9120
-	AUDIO_F32		 = AUDIO_F32LSB
+	AUDIO_F32LSB = 0x8120
+	AUDIO_F32MSB = 0x9120
+	AUDIO_F32    = AUDIO_F32LSB
 )
 
 const (
-	AUDIO_U16SYS		= C.AUDIO_U16SYS
-	AUDIO_S16SYS		= C.AUDIO_S16SYS
-	AUDIO_S32SYS		= C.AUDIO_S32SYS
-	AUDIO_F32SYS		= C.AUDIO_F32SYS
+	AUDIO_U16SYS = C.AUDIO_U16SYS
+	AUDIO_S16SYS = C.AUDIO_S16SYS
+	AUDIO_S32SYS = C.AUDIO_S32SYS
+	AUDIO_F32SYS = C.AUDIO_F32SYS
 )
 
 const (
-	AUDIO_ALLOW_FREQUENCY_CHANGE	= 0x00000001
-	AUDIO_ALLOW_FORMAT_CHANGE	= 0x00000002
-	AUDIO_ALLOW_CHANNELS_CHANGE	= 0x00000004
-	AUDIO_ALLOW_ANY_CHANGE		= (AUDIO_ALLOW_FREQUENCY_CHANGE |
-					   AUDIO_ALLOW_FORMAT_CHANGE |
-					   AUDIO_ALLOW_CHANNELS_CHANGE)
+	AUDIO_ALLOW_FREQUENCY_CHANGE = 0x00000001
+	AUDIO_ALLOW_FORMAT_CHANGE    = 0x00000002
+	AUDIO_ALLOW_CHANNELS_CHANGE  = 0x00000004
+	AUDIO_ALLOW_ANY_CHANGE       = (AUDIO_ALLOW_FREQUENCY_CHANGE |
+		AUDIO_ALLOW_FORMAT_CHANGE |
+		AUDIO_ALLOW_CHANNELS_CHANGE)
 )
 
 const (
-	AUDIO_STOPPED			= iota
+	AUDIO_STOPPED = iota
 	AUDIO_PLAYING
 	AUDIO_PAUSED
 )
@@ -67,33 +67,33 @@ type AudioDeviceID uint32
 type AudioStatus uint
 
 type AudioSpec struct {
-	Freq int
-	Format AudioFormat
+	Freq     int
+	Format   AudioFormat
 	Channels uint8
-	Silence uint8
-	Samples uint16
-	Padding uint16
-	Size uint32
+	Silence  uint8
+	Samples  uint16
+	Padding  uint16
+	Size     uint32
 	Callback AudioCallback
 	UserData unsafe.Pointer
 }
 
 type AudioCVT struct {
-	Needed int
-	SrcFormat AudioFormat
-	DstFormat AudioFormat
-	RateIncr float64
-	Buf	*uint8
-	Len int
-	LenCVT int
-	LenMult int
-	LenRatio float64
-	filters [10]AudioFilter
+	Needed      int
+	SrcFormat   AudioFormat
+	DstFormat   AudioFormat
+	RateIncr    float64
+	Buf         *uint8
+	Len         int
+	LenCVT      int
+	LenMult     int
+	LenRatio    float64
+	filters     [10]AudioFilter
 	FilterIndex int
 }
 
 func (format AudioFormat) BitSize() uint8 {
-	return (uint8) (format & AUDIO_MASK_BITSIZE)
+	return (uint8)(format & AUDIO_MASK_BITSIZE)
 }
 
 func (format AudioFormat) IsFloat() bool {
@@ -121,17 +121,18 @@ func (format AudioFormat) IsUnsigned() bool {
 }
 
 func GetNumAudioDrivers() int {
-	return (int) (C.SDL_GetNumAudioDrivers())
+	return (int)(C.SDL_GetNumAudioDrivers())
 }
 
 func GetAudioDriver(index int) string {
-	_index := (C.int) (index)
-	return (string) (C.GoString(C.SDL_GetAudioDriver(_index)))
+	_index := (C.int)(index)
+	return (string)(C.GoString(C.SDL_GetAudioDriver(_index)))
 }
 
 func AudioInit(driver_name string) int {
-	_driver_name := (C.CString) (driver_name)
-	return (int) (C.SDL_AudioInit(_driver_name))
+	_driver_name := C.CString(driver_name)
+	defer C.free(unsafe.Pointer(_driver_name))
+	return (int)(C.SDL_AudioInit(_driver_name))
 }
 
 func AudioQuit() {
@@ -139,139 +140,142 @@ func AudioQuit() {
 }
 
 func GetCurrentAudioDriver() string {
-	return (string) (C.GoString(C.SDL_GetCurrentAudioDriver()))
+	return (string)(C.GoString(C.SDL_GetCurrentAudioDriver()))
 }
 
 func OpenAudio(desired, obtained *AudioSpec) int {
-	_desired := (*C.SDL_AudioSpec) (unsafe.Pointer(desired))
-	_obtained := (*C.SDL_AudioSpec) (unsafe.Pointer(obtained))
-	return (int) (C.SDL_OpenAudio(_desired, _obtained))
+	_desired := (*C.SDL_AudioSpec)(unsafe.Pointer(desired))
+	_obtained := (*C.SDL_AudioSpec)(unsafe.Pointer(obtained))
+	return (int)(C.SDL_OpenAudio(_desired, _obtained))
 }
 
 func GetNumAudioDevices(iscapture int) int {
-	_iscapture := (C.int) (iscapture)
-	return (int) (C.SDL_GetNumAudioDevices(_iscapture))
+	_iscapture := (C.int)(iscapture)
+	return (int)(C.SDL_GetNumAudioDevices(_iscapture))
 }
 
 func GetAudioDeviceName(index, iscapture int) string {
-	_index := (C.int) (index)
-	_iscapture := (C.int) (iscapture)
-	return (string) (C.GoString(C.SDL_GetAudioDeviceName(_index, _iscapture)))
+	_index := (C.int)(index)
+	_iscapture := (C.int)(iscapture)
+	return (string)(C.GoString(C.SDL_GetAudioDeviceName(_index, _iscapture)))
 }
 
 func OpenAudioDevice(device string, iscapture int, desired, obtained *AudioSpec, allowed_changes int) int {
-	_device := (C.CString) (device)
-	_iscapture := (C.int) (iscapture)
-	_desired := (*C.SDL_AudioSpec) (unsafe.Pointer(desired))
-	_obtained := (*C.SDL_AudioSpec) (unsafe.Pointer(obtained))
-	_allowed_changes := (C.int) (allowed_changes)
-	return (int) (C.SDL_OpenAudioDevice(_device, _iscapture, _desired, _obtained, _allowed_changes))
+	_device := C.CString(device)
+	defer C.free(unsafe.Pointer(_device))
+	_iscapture := (C.int)(iscapture)
+	_desired := (*C.SDL_AudioSpec)(unsafe.Pointer(desired))
+	_obtained := (*C.SDL_AudioSpec)(unsafe.Pointer(obtained))
+	_allowed_changes := (C.int)(allowed_changes)
+	return (int)(C.SDL_OpenAudioDevice(_device, _iscapture, _desired, _obtained, _allowed_changes))
 }
 
 func GetAudioStatus() AudioStatus {
-	return (AudioStatus) (C.SDL_GetAudioStatus())
+	return (AudioStatus)(C.SDL_GetAudioStatus())
 }
 
-
 func GetAudioDeviceStatus(dev AudioDeviceID) AudioStatus {
-	_dev := (C.SDL_AudioDeviceID) (dev)
-	return (AudioStatus) (C.SDL_GetAudioDeviceStatus(_dev))
+	_dev := (C.SDL_AudioDeviceID)(dev)
+	return (AudioStatus)(C.SDL_GetAudioDeviceStatus(_dev))
 }
 
 func PauseAudio(pause_on int) {
-	_pause_on := (C.int) (pause_on)
+	_pause_on := (C.int)(pause_on)
 	C.SDL_PauseAudio(_pause_on)
 }
 
 func PauseAudioDevice(dev AudioDeviceID, pause_on int) {
-	_dev := (C.SDL_AudioDeviceID) (dev)
-	_pause_on := (C.int) (pause_on)
+	_dev := (C.SDL_AudioDeviceID)(dev)
+	_pause_on := (C.int)(pause_on)
 	C.SDL_PauseAudioDevice(_dev, _pause_on)
 }
 
 func LoadWAV_RW(src *RWops, freesrc int, spec *AudioSpec, audio_buf **uint8, audio_len *uint32) *AudioSpec {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	_freesrc := (C.int) (freesrc)
-	_spec := (*C.SDL_AudioSpec) (unsafe.Pointer(spec))
-	_audio_buf := (**C.Uint8) (unsafe.Pointer(audio_buf))
-	_audio_len := (*C.Uint32) (unsafe.Pointer(audio_len))
-	return (*AudioSpec) (unsafe.Pointer(C.SDL_LoadWAV_RW(_src, _freesrc, _spec, _audio_buf, _audio_len)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	_freesrc := (C.int)(freesrc)
+	_spec := (*C.SDL_AudioSpec)(unsafe.Pointer(spec))
+	_audio_buf := (**C.Uint8)(unsafe.Pointer(audio_buf))
+	_audio_len := (*C.Uint32)(unsafe.Pointer(audio_len))
+	return (*AudioSpec)(unsafe.Pointer(C.SDL_LoadWAV_RW(_src, _freesrc, _spec, _audio_buf, _audio_len)))
 }
 
 func LoadWAV(file string, spec *AudioSpec, audio_buf **uint8, audio_len *uint32) *AudioSpec {
-	_file := (C.CString) (file)
-	_spec := (*C.SDL_AudioSpec) (unsafe.Pointer(spec))
-	_audio_buf := (**C.Uint8) (unsafe.Pointer(audio_buf))
-	_audio_len := (*C.Uint32) (unsafe.Pointer(audio_len))
-	return (*AudioSpec) (unsafe.Pointer(C.SDL_LoadWAV_RW(C.SDL_RWFromFile(_file, C.CString("rb")),
-					1, _spec, _audio_buf, _audio_len)))
+	_file := C.CString(file)
+	defer C.free(unsafe.Pointer(_file))
+	_rb := C.CString("rb")
+	defer C.free(unsafe.Pointer(_rb))
+	_spec := (*C.SDL_AudioSpec)(unsafe.Pointer(spec))
+	_audio_buf := (**C.Uint8)(unsafe.Pointer(audio_buf))
+	_audio_len := (*C.Uint32)(unsafe.Pointer(audio_len))
+	return (*AudioSpec)(unsafe.Pointer(C.SDL_LoadWAV_RW(C.SDL_RWFromFile(_file, _rb),
+		1, _spec, _audio_buf, _audio_len)))
 }
 
 func FreeWAV(audio_buf *uint8) {
-	_audio_buf := (*C.Uint8) (unsafe.Pointer(audio_buf))
+	_audio_buf := (*C.Uint8)(unsafe.Pointer(audio_buf))
 	C.SDL_FreeWAV(_audio_buf)
 }
 
 func BuildAudioCVT(cvt *AudioCVT, src_format AudioFormat, src_channels uint8, src_rate int,
-		dst_format AudioFormat, dst_channels uint8, dst_rate int) int {
-	_cvt := (*C.SDL_AudioCVT) (unsafe.Pointer(cvt))
-	_src_format := (C.SDL_AudioFormat) (src_format)
-	_src_channels := (C.Uint8) (src_channels)
-	_src_rate := (C.int) (src_rate)
-	_dst_format := (C.SDL_AudioFormat) (dst_format)
-	_dst_channels := (C.Uint8) (dst_channels)
-	_dst_rate := (C.int) (dst_rate)
-	return (int) (C.SDL_BuildAudioCVT(_cvt, _src_format, _src_channels, _src_rate,
-					_dst_format, _dst_channels, _dst_rate))
+	dst_format AudioFormat, dst_channels uint8, dst_rate int) int {
+	_cvt := (*C.SDL_AudioCVT)(unsafe.Pointer(cvt))
+	_src_format := (C.SDL_AudioFormat)(src_format)
+	_src_channels := (C.Uint8)(src_channels)
+	_src_rate := (C.int)(src_rate)
+	_dst_format := (C.SDL_AudioFormat)(dst_format)
+	_dst_channels := (C.Uint8)(dst_channels)
+	_dst_rate := (C.int)(dst_rate)
+	return (int)(C.SDL_BuildAudioCVT(_cvt, _src_format, _src_channels, _src_rate,
+		_dst_format, _dst_channels, _dst_rate))
 }
 
 func ConvertAudio(cvt *AudioCVT) int {
-	_cvt := (*C.SDL_AudioCVT) (unsafe.Pointer(cvt))
-	return (int) (C.SDL_ConvertAudio(_cvt))
+	_cvt := (*C.SDL_AudioCVT)(unsafe.Pointer(cvt))
+	return (int)(C.SDL_ConvertAudio(_cvt))
 }
 
 func MixAudio(dst, src *uint8, len_ uint32, volume int) {
-	_dst := (*C.Uint8) (unsafe.Pointer(dst))
-	_src := (*C.Uint8) (unsafe.Pointer(src))
-	_len := (C.Uint32) (len_)
-	_volume := (C.int) (volume)
+	_dst := (*C.Uint8)(unsafe.Pointer(dst))
+	_src := (*C.Uint8)(unsafe.Pointer(src))
+	_len := (C.Uint32)(len_)
+	_volume := (C.int)(volume)
 	C.SDL_MixAudio(_dst, _src, _len, _volume)
 }
 
 func MixAudioFormat(dst, src *uint8, format AudioFormat, len_ uint32, volume int) {
-	_dst := (*C.Uint8) (unsafe.Pointer(dst))
-	_src := (*C.Uint8) (unsafe.Pointer(src))
-	_format := (C.SDL_AudioFormat) (format)
-	_len := (C.Uint32) (len_)
-	_volume := (C.int) (volume)
+	_dst := (*C.Uint8)(unsafe.Pointer(dst))
+	_src := (*C.Uint8)(unsafe.Pointer(src))
+	_format := (C.SDL_AudioFormat)(format)
+	_len := (C.Uint32)(len_)
+	_volume := (C.int)(volume)
 	C.SDL_MixAudioFormat(_dst, _src, _format, _len, _volume)
 }
 
 func LockAudio() {
-	C.SDL_LockAudio();
+	C.SDL_LockAudio()
 }
 
 func LockAudioDevice(dev AudioDeviceID) {
-	_dev := (C.SDL_AudioDeviceID) (dev)
-	C.SDL_LockAudioDevice(_dev);
+	_dev := (C.SDL_AudioDeviceID)(dev)
+	C.SDL_LockAudioDevice(_dev)
 }
 
 func UnlockAudio() {
-	C.SDL_UnlockAudio();
+	C.SDL_UnlockAudio()
 }
 
 func UnlockAudioDevice(dev AudioDeviceID) {
-	_dev := (C.SDL_AudioDeviceID) (dev)
-	C.SDL_UnlockAudioDevice(_dev);
+	_dev := (C.SDL_AudioDeviceID)(dev)
+	C.SDL_UnlockAudioDevice(_dev)
 }
 
 func CloseAudio() {
-	C.SDL_UnlockAudio();
+	C.SDL_UnlockAudio()
 }
 
 func CloseAudioDevice(dev AudioDeviceID) {
-	_dev := (C.SDL_AudioDeviceID) (dev)
-	C.SDL_UnlockAudioDevice(_dev);
+	_dev := (C.SDL_AudioDeviceID)(dev)
+	C.SDL_UnlockAudioDevice(_dev)
 }
 
 /*

--- a/sdl/sdl_clipboard.go
+++ b/sdl/sdl_clipboard.go
@@ -6,13 +6,13 @@ import "C"
 import "unsafe"
 
 func SetClipboardText(text string) int {
-	_text := (C.CString) (text)
+	_text := C.CString(text)
 	defer C.SDL_free(unsafe.Pointer(_text))
-	return (int) (C.SDL_SetClipboardText(_text))
+	return (int)(C.SDL_SetClipboardText(_text))
 }
 
 func GetClipboardText() string {
-	return (C.GoString) (C.SDL_GetClipboardText())
+	return C.GoString(C.SDL_GetClipboardText())
 }
 
 func HasClipboardText() bool {

--- a/sdl/sdl_error.go
+++ b/sdl/sdl_error.go
@@ -5,17 +5,17 @@ import "C"
 import "errors"
 
 const (
-	ENOMEM				= 0x00000000
-	EFREAD				= 0x00000001
-	EFWRITE				= 0x00000002
-	EFSEEK				= 0x00000003
-	UNSUPPORTED			= 0x00000004
-	LASTERROR			= 0x00000005
+	ENOMEM      = 0x00000000
+	EFREAD      = 0x00000001
+	EFWRITE     = 0x00000002
+	EFSEEK      = 0x00000003
+	UNSUPPORTED = 0x00000004
+	LASTERROR   = 0x00000005
 )
 
 func GetError() error {
 	_c_err := C.SDL_GetError()
-	if _c_err == nil {
+	if *_c_err == 0 {
 		return nil
 	}
 	return errors.New(C.GoString(_c_err))
@@ -26,7 +26,7 @@ func ClearError() {
 }
 
 func Error(code int) {
-	_code := (C.SDL_errorcode) (C.int(code))
+	_code := (C.SDL_errorcode)(C.int(code))
 	C.SDL_Error(_code)
 }
 

--- a/sdl/sdl_gamecontroller.go
+++ b/sdl/sdl_gamecontroller.go
@@ -49,49 +49,49 @@ type GameController C.SDL_GameController
 type GameControllerButtonBind C.SDL_GameControllerButtonBind
 
 func GameControllerAddMapping(mappingString string) int {
-	_mappingString := (C.CString) (mappingString)
+	_mappingString := C.CString(mappingString)
 	defer C.SDL_free(unsafe.Pointer(_mappingString))
-	return (int) (C.SDL_GameControllerAddMapping(_mappingString))
+	return (int)(C.SDL_GameControllerAddMapping(_mappingString))
 }
 
 func GameControllerMappingForGUID(guid JoystickGUID) string {
-	_guid := (C.SDL_JoystickGUID) (guid)
-	return (C.GoString) (C.SDL_GameControllerMappingForGUID(_guid))
+	_guid := (C.SDL_JoystickGUID)(guid)
+	return (C.GoString)(C.SDL_GameControllerMappingForGUID(_guid))
 }
 
 func GameControllerMapping(gamecontroller *GameController) string {
-	_gamecontroller := (*C.SDL_GameController) (gamecontroller)
-	return (C.GoString) (C.SDL_GameControllerMapping(_gamecontroller))
+	_gamecontroller := (*C.SDL_GameController)(gamecontroller)
+	return (C.GoString)(C.SDL_GameControllerMapping(_gamecontroller))
 }
 
 func IsGameController(joystick_index int) bool {
-	_joystick_index := (C.int) (joystick_index)
+	_joystick_index := (C.int)(joystick_index)
 	return C.SDL_IsGameController(_joystick_index) > 0
 }
 
 func GameControllerNameForIndex(joystick_index int) string {
-	_joystick_index := (C.int) (joystick_index)
-	return (C.GoString) (C.SDL_GameControllerNameForIndex(_joystick_index))
+	_joystick_index := (C.int)(joystick_index)
+	return (C.GoString)(C.SDL_GameControllerNameForIndex(_joystick_index))
 }
 
 func GameControllerOpen(joystick_index int) *GameController {
-	_joystick_index := (C.int) (joystick_index)
-	return (*GameController) (unsafe.Pointer(C.SDL_GameControllerOpen(_joystick_index)))
+	_joystick_index := (C.int)(joystick_index)
+	return (*GameController)(unsafe.Pointer(C.SDL_GameControllerOpen(_joystick_index)))
 }
 
 func (gamecontroller *GameController) GetAttached() bool {
-	_gamecontroller := (*C.SDL_GameController) (unsafe.Pointer(gamecontroller))
+	_gamecontroller := (*C.SDL_GameController)(unsafe.Pointer(gamecontroller))
 	return C.SDL_GameControllerGetAttached(_gamecontroller) > 0
 }
 
 func (gamecontroller *GameController) GetJoystick() *Joystick {
-	_gamecontroller := (*C.SDL_GameController) (unsafe.Pointer(gamecontroller))
-	return (*Joystick) (unsafe.Pointer(C.SDL_GameControllerGetJoystick(_gamecontroller)))
+	_gamecontroller := (*C.SDL_GameController)(unsafe.Pointer(gamecontroller))
+	return (*Joystick)(unsafe.Pointer(C.SDL_GameControllerGetJoystick(_gamecontroller)))
 }
 
 func GameControllerEventState(state int) int {
-	_state := (C.int) (state)
-	return (int) (C.SDL_GameControllerEventState(_state))
+	_state := (C.int)(state)
+	return (int)(C.SDL_GameControllerEventState(_state))
 }
 
 func GameControllerUpdate() {
@@ -99,52 +99,52 @@ func GameControllerUpdate() {
 }
 
 func GameControllerGetAxisFromString(pchString string) GameControllerAxis {
-	_pchString := (C.CString) (pchString)
+	_pchString := C.CString(pchString)
 	defer C.SDL_free(unsafe.Pointer(_pchString))
-	return (GameControllerAxis) (C.SDL_GameControllerGetAxisFromString(_pchString))
+	return (GameControllerAxis)(C.SDL_GameControllerGetAxisFromString(_pchString))
 }
 
 func GameControllerGetStringForAxis(axis GameControllerAxis) string {
-	_axis := (C.SDL_GameControllerAxis) (axis)
-	return (C.GoString) (C.SDL_GameControllerGetStringForAxis(_axis))
+	_axis := (C.SDL_GameControllerAxis)(axis)
+	return (C.GoString)(C.SDL_GameControllerGetStringForAxis(_axis))
 }
 
 func (gamecontroller *GameController) GetBindForAxis(axis GameControllerAxis) GameControllerButtonBind {
-	_gamecontroller := (*C.SDL_GameController) (gamecontroller)
-	_axis := (C.SDL_GameControllerAxis) (axis)
-	return (GameControllerButtonBind) (C.SDL_GameControllerGetBindForAxis(_gamecontroller, _axis))
+	_gamecontroller := (*C.SDL_GameController)(gamecontroller)
+	_axis := (C.SDL_GameControllerAxis)(axis)
+	return (GameControllerButtonBind)(C.SDL_GameControllerGetBindForAxis(_gamecontroller, _axis))
 }
 
 func (gamecontroller *GameController) GetAxis(axis GameControllerAxis) int16 {
-	_gamecontroller := (*C.SDL_GameController) (gamecontroller)
-	_axis := (C.SDL_GameControllerAxis) (axis)
-	return (int16) (C.SDL_GameControllerGetAxis(_gamecontroller, _axis))
+	_gamecontroller := (*C.SDL_GameController)(gamecontroller)
+	_axis := (C.SDL_GameControllerAxis)(axis)
+	return (int16)(C.SDL_GameControllerGetAxis(_gamecontroller, _axis))
 }
 
 func GameControllerGetButtonFromString(pchString string) GameControllerButton {
-	_pchString := (C.CString) (pchString)
+	_pchString := C.CString(pchString)
 	defer C.SDL_free(unsafe.Pointer(_pchString))
-	return (GameControllerButton) (C.SDL_GameControllerGetButtonFromString(_pchString))
+	return (GameControllerButton)(C.SDL_GameControllerGetButtonFromString(_pchString))
 }
 
 func GameControllerGetStringForButton(button GameControllerButton) string {
-	_button := (C.SDL_GameControllerButton) (button)
-	return (C.GoString) (C.SDL_GameControllerGetStringForButton(_button))
+	_button := (C.SDL_GameControllerButton)(button)
+	return (C.GoString)(C.SDL_GameControllerGetStringForButton(_button))
 }
 
 func (gamecontroller *GameController) GetBindForButton(button GameControllerButton) GameControllerButtonBind {
-	_gamecontroller := (*C.SDL_GameController) (gamecontroller)
-	_button := (C.SDL_GameControllerButton) (button)
-	return (GameControllerButtonBind) (C.SDL_GameControllerGetBindForButton(_gamecontroller, _button))
+	_gamecontroller := (*C.SDL_GameController)(gamecontroller)
+	_button := (C.SDL_GameControllerButton)(button)
+	return (GameControllerButtonBind)(C.SDL_GameControllerGetBindForButton(_gamecontroller, _button))
 }
 
 func (gamecontroller *GameController) GetButton(button GameControllerButton) byte {
-	_gamecontroller := (*C.SDL_GameController) (gamecontroller)
-	_button := (C.SDL_GameControllerButton) (button)
-	return (byte) (C.SDL_GameControllerGetButton(_gamecontroller, _button))
+	_gamecontroller := (*C.SDL_GameController)(gamecontroller)
+	_button := (C.SDL_GameControllerButton)(button)
+	return (byte)(C.SDL_GameControllerGetButton(_gamecontroller, _button))
 }
 
 func (gamecontroller *GameController) Close() {
-	_gamecontroller := (*C.SDL_GameController) (gamecontroller)
+	_gamecontroller := (*C.SDL_GameController)(gamecontroller)
 	C.SDL_GameControllerClose(_gamecontroller)
 }

--- a/sdl/sdl_joystick.go
+++ b/sdl/sdl_joystick.go
@@ -5,15 +5,15 @@ import "C"
 import "unsafe"
 
 const (
-	HAT_CENTERED	= 0x00
-	HAT_UP		= 0x01
-	HAT_RIGHT	= 0x02
-	HAT_DOWN	= 0x04
-	HAT_LEFT	= 0x08
-	HAT_RIGHTUP     = HAT_RIGHT | HAT_UP
-	HAT_RIGHTDOWN   = HAT_RIGHT | HAT_DOWN
-	HAT_LEFTUP      = HAT_LEFT | HAT_UP
-	HAT_LEFTDOWN    = HAT_LEFT | HAT_DOWN
+	HAT_CENTERED  = 0x00
+	HAT_UP        = 0x01
+	HAT_RIGHT     = 0x02
+	HAT_DOWN      = 0x04
+	HAT_LEFT      = 0x08
+	HAT_RIGHTUP   = HAT_RIGHT | HAT_UP
+	HAT_RIGHTDOWN = HAT_RIGHT | HAT_DOWN
+	HAT_LEFTUP    = HAT_LEFT | HAT_UP
+	HAT_LEFTDOWN  = HAT_LEFT | HAT_DOWN
 )
 
 type Joystick C.SDL_Joystick
@@ -21,76 +21,76 @@ type JoystickGUID C.SDL_JoystickGUID
 type JoystickID C.SDL_JoystickID
 
 func NumJoysticks() int {
-	return (int) (C.SDL_NumJoysticks())
+	return (int)(C.SDL_NumJoysticks())
 }
 
 func JoystickNameForIndex(device_index int) string {
-	_device_index := (C.int) (device_index)
-	return (C.GoString) (C.SDL_JoystickNameForIndex(_device_index))
+	_device_index := (C.int)(device_index)
+	return (C.GoString)(C.SDL_JoystickNameForIndex(_device_index))
 }
 
 func JoystickOpen(device_index int) *Joystick {
-	_device_index := (C.int) (device_index)
-	return (*Joystick) (C.SDL_JoystickOpen(_device_index))
+	_device_index := (C.int)(device_index)
+	return (*Joystick)(C.SDL_JoystickOpen(_device_index))
 }
 
 func (joystick *Joystick) Name() string {
-	_joystick := (*C.SDL_Joystick) (joystick)
-	return (C.GoString) (C.SDL_JoystickName(_joystick))
+	_joystick := (*C.SDL_Joystick)(joystick)
+	return (C.GoString)(C.SDL_JoystickName(_joystick))
 }
 
 func JoystickGetDeviceGUID(device_index int) JoystickGUID {
-	_device_index := (C.int) (device_index)
-	return (JoystickGUID) (C.SDL_JoystickGetDeviceGUID(_device_index))
+	_device_index := (C.int)(device_index)
+	return (JoystickGUID)(C.SDL_JoystickGetDeviceGUID(_device_index))
 }
 
 func (joystick *Joystick) GetGUID() JoystickGUID {
-	_joystick := (*C.SDL_Joystick) (joystick)
-	return (JoystickGUID) (C.SDL_JoystickGetGUID(_joystick))
+	_joystick := (*C.SDL_Joystick)(joystick)
+	return (JoystickGUID)(C.SDL_JoystickGetGUID(_joystick))
 }
 
 func JoystickGetGUIDString(guid JoystickGUID, pszGUID string, cbGUID int) {
-	_guid := (C.SDL_JoystickGUID) (guid)
-	_pszGUID := (C.CString) (pszGUID)
-	_cbGUID := (C.int) (cbGUID)
+	_guid := (C.SDL_JoystickGUID)(guid)
+	_pszGUID := C.CString(pszGUID)
 	defer C.SDL_free(unsafe.Pointer(_pszGUID))
+	_cbGUID := (C.int)(cbGUID)
 	C.SDL_JoystickGetGUIDString(_guid, _pszGUID, _cbGUID)
 }
 
 func JoystickGetGUIDFromString(pchGUID string) JoystickGUID {
-	_pchGUID := (C.CString) (pchGUID)
+	_pchGUID := C.CString(pchGUID)
 	defer C.SDL_free(unsafe.Pointer(_pchGUID))
-	return (JoystickGUID) (C.SDL_JoystickGetGUIDFromString(_pchGUID))
+	return (JoystickGUID)(C.SDL_JoystickGetGUIDFromString(_pchGUID))
 }
 
 func (joystick *Joystick) GetAttached() bool {
-	_joystick := (*C.SDL_Joystick) (joystick)
+	_joystick := (*C.SDL_Joystick)(joystick)
 	return C.SDL_JoystickGetAttached(_joystick) > 0
 }
 
 func (joystick *Joystick) InstanceID() JoystickID {
-	_joystick := (*C.SDL_Joystick) (joystick)
-	return (JoystickID) (C.SDL_JoystickInstanceID(_joystick))
+	_joystick := (*C.SDL_Joystick)(joystick)
+	return (JoystickID)(C.SDL_JoystickInstanceID(_joystick))
 }
 
 func (joystick *Joystick) NumAxes() int {
-	_joystick := (*C.SDL_Joystick) (joystick)
-	return (int) (C.SDL_JoystickNumAxes(_joystick))
+	_joystick := (*C.SDL_Joystick)(joystick)
+	return (int)(C.SDL_JoystickNumAxes(_joystick))
 }
 
 func (joystick *Joystick) NumBalls() int {
-	_joystick := (*C.SDL_Joystick) (joystick)
-	return (int) (C.SDL_JoystickNumBalls(_joystick))
+	_joystick := (*C.SDL_Joystick)(joystick)
+	return (int)(C.SDL_JoystickNumBalls(_joystick))
 }
 
 func (joystick *Joystick) NumHats() int {
-	_joystick := (*C.SDL_Joystick) (joystick)
-	return (int) (C.SDL_JoystickNumHats(_joystick))
+	_joystick := (*C.SDL_Joystick)(joystick)
+	return (int)(C.SDL_JoystickNumHats(_joystick))
 }
 
 func (joystick *Joystick) NumButtons() int {
-	_joystick := (*C.SDL_Joystick) (joystick)
-	return (int) (C.SDL_JoystickNumButtons(_joystick))
+	_joystick := (*C.SDL_Joystick)(joystick)
+	return (int)(C.SDL_JoystickNumButtons(_joystick))
 }
 
 func Update() {
@@ -98,37 +98,37 @@ func Update() {
 }
 
 func JoystickEventState(state int) int {
-	_state := (C.int) (state)
-	return (int) (C.SDL_JoystickEventState(_state))
+	_state := (C.int)(state)
+	return (int)(C.SDL_JoystickEventState(_state))
 }
 
 func (joystick *Joystick) GetAxis(axis int) int16 {
-	_joystick := (*C.SDL_Joystick) (joystick)
-	_axis := (C.int) (axis)
-	return (int16) (C.SDL_JoystickGetAxis(_joystick, _axis))
+	_joystick := (*C.SDL_Joystick)(joystick)
+	_axis := (C.int)(axis)
+	return (int16)(C.SDL_JoystickGetAxis(_joystick, _axis))
 }
 
 func (joystick *Joystick) GetHat(hat int) byte {
-	_joystick := (*C.SDL_Joystick) (joystick)
-	_hat := (C.int) (hat)
-	return (byte) (C.SDL_JoystickGetHat(_joystick, _hat))
+	_joystick := (*C.SDL_Joystick)(joystick)
+	_hat := (C.int)(hat)
+	return (byte)(C.SDL_JoystickGetHat(_joystick, _hat))
 }
 
 func (joystick *Joystick) GetBall(ball int, dx, dy *int) int {
-	_joystick := (*C.SDL_Joystick) (joystick)
-	_ball := (C.int) (ball)
-	_dx := (*C.int) (unsafe.Pointer(dx))
-	_dy := (*C.int) (unsafe.Pointer(dy))
-	return (int) (C.SDL_JoystickGetBall(_joystick, _ball, _dx, _dy))
+	_joystick := (*C.SDL_Joystick)(joystick)
+	_ball := (C.int)(ball)
+	_dx := (*C.int)(unsafe.Pointer(dx))
+	_dy := (*C.int)(unsafe.Pointer(dy))
+	return (int)(C.SDL_JoystickGetBall(_joystick, _ball, _dx, _dy))
 }
 
 func (joystick *Joystick) GetButton(button int) byte {
-	_joystick := (*C.SDL_Joystick) (joystick)
-	_button := (C.int) (button)
-	return (byte) (C.SDL_JoystickGetButton(_joystick, _button))
+	_joystick := (*C.SDL_Joystick)(joystick)
+	_button := (C.int)(button)
+	return (byte)(C.SDL_JoystickGetButton(_joystick, _button))
 }
 
 func (joystick *Joystick) Close() {
-	_joystick := (*C.SDL_Joystick) (joystick)
+	_joystick := (*C.SDL_Joystick)(joystick)
 	C.SDL_JoystickClose(_joystick)
 }

--- a/sdl/sdl_keyboard.go
+++ b/sdl/sdl_keyboard.go
@@ -7,13 +7,13 @@ import "reflect"
 
 type Keysym struct {
 	Scancode Scancode
-	Sym Keycode
-	Mod uint16
-	Unicode uint32
+	Sym      Keycode
+	Mod      uint16
+	Unicode  uint32
 }
 
 func GetKeyboardFocus() *Window {
-	return (*Window) (unsafe.Pointer(C.SDL_GetKeyboardFocus()))
+	return (*Window)(unsafe.Pointer(C.SDL_GetKeyboardFocus()))
 }
 
 func GetKeyboardState() []uint8 {
@@ -27,38 +27,40 @@ func GetKeyboardState() []uint8 {
 }
 
 func SetModState(modstate Keymod) {
-	_modstate := (C.SDL_Keymod) (modstate)
+	_modstate := (C.SDL_Keymod)(modstate)
 	C.SDL_SetModState(_modstate)
 }
 
 func GetKeyFromScancode(scancode Scancode) Keycode {
-	_scancode := (C.SDL_Scancode) (scancode)
-	return (Keycode) (C.SDL_GetKeyFromScancode(_scancode))
+	_scancode := (C.SDL_Scancode)(scancode)
+	return (Keycode)(C.SDL_GetKeyFromScancode(_scancode))
 }
 
 func GetScancodeFromKey(key Keycode) Scancode {
-	_key := (C.SDL_Keycode) (key)
-	return (Scancode) (C.SDL_GetScancodeFromKey(_key))
+	_key := (C.SDL_Keycode)(key)
+	return (Scancode)(C.SDL_GetScancodeFromKey(_key))
 }
 
 func GetScancodeName(scancode Scancode) string {
-	_scancode := (C.SDL_Scancode) (scancode)
-	return (C.GoString) (C.SDL_GetScancodeName(_scancode))
+	_scancode := (C.SDL_Scancode)(scancode)
+	return (C.GoString)(C.SDL_GetScancodeName(_scancode))
 }
 
 func GetScancodeFromName(name string) Scancode {
-	_name := (C.CString) (name)
-	return (Scancode) (C.SDL_GetScancodeFromName(_name))
+	_name := C.CString(name)
+	defer C.free(unsafe.Pointer(_name))
+	return (Scancode)(C.SDL_GetScancodeFromName(_name))
 }
 
 func GetKeyName(key Keycode) string {
-	_key := (C.SDL_Keycode) (key)
-	return (C.GoString) (C.SDL_GetKeyName(_key))
+	_key := (C.SDL_Keycode)(key)
+	return (C.GoString)(C.SDL_GetKeyName(_key))
 }
 
 func GetKeyFromName(name string) Keycode {
-	_name := (C.CString) (name)
-	return (Keycode) (C.SDL_GetKeyFromName(_name))
+	_name := C.CString(name)
+	defer C.free(unsafe.Pointer(_name))
+	return (Keycode)(C.SDL_GetKeyFromName(_name))
 }
 
 func StartTextInput() {
@@ -74,7 +76,7 @@ func StopTextInput() {
 }
 
 func SetTextInputRect(rect *Rect) {
-	_rect := (*C.SDL_Rect) (unsafe.Pointer(rect))
+	_rect := (*C.SDL_Rect)(unsafe.Pointer(rect))
 	C.SDL_SetTextInputRect(_rect)
 }
 
@@ -83,6 +85,6 @@ func HasScreenKeyboardSupport() bool {
 }
 
 func IsScreenKeyboardShown(window *Window) bool {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
 	return C.SDL_IsScreenKeyboardShown(_window) > 0
 }

--- a/sdl/sdl_loadso.go
+++ b/sdl/sdl_loadso.go
@@ -5,15 +5,15 @@ import "C"
 import "unsafe"
 
 func LoadObject(sofile string) unsafe.Pointer {
-	_sofile := (C.CString) (sofile)
+	_sofile := C.CString(sofile)
 	defer C.SDL_free(unsafe.Pointer(_sofile))
-	return (unsafe.Pointer) (C.SDL_LoadObject(_sofile))
+	return (unsafe.Pointer)(C.SDL_LoadObject(_sofile))
 }
 
 func LoadFunction(handle unsafe.Pointer, name string) unsafe.Pointer {
-	_name := (C.CString) (name)
+	_name := C.CString(name)
 	defer C.SDL_free(unsafe.Pointer(_name))
-	return (unsafe.Pointer) (C.SDL_LoadFunction(handle, _name))
+	return (unsafe.Pointer)(C.SDL_LoadFunction(handle, _name))
 }
 
 func UnloadObject(handle unsafe.Pointer) {

--- a/sdl/sdl_mouse.go
+++ b/sdl/sdl_mouse.go
@@ -24,42 +24,42 @@ const (
 )
 
 const (
-	BUTTON_LEFT     = 1
-	BUTTON_MIDDLE   = 2
-	BUTTON_RIGHT    = 3
-	BUTTON_X1       = 4
-	BUTTON_X2       = 5
+	BUTTON_LEFT   = 1
+	BUTTON_MIDDLE = 2
+	BUTTON_RIGHT  = 3
+	BUTTON_X1     = 4
+	BUTTON_X2     = 5
 )
 
 type Cursor C.SDL_Cursor
 type SystemCursor C.SDL_SystemCursor
 
 func GetMouseFocus() *Window {
-	return (*Window) (unsafe.Pointer(C.SDL_GetMouseFocus()))
+	return (*Window)(unsafe.Pointer(C.SDL_GetMouseFocus()))
 }
 
-func GetMouseState(x, y *int) uint32 {
-	_x := (*C.int) (unsafe.Pointer(x))
-	_y := (*C.int) (unsafe.Pointer(y))
-	return (uint32) (C.SDL_GetMouseState(_x, _y))
+func GetMouseState() (x, y int, state uint32) {
+	var _x, _y C.int
+	_state := uint32(C.SDL_GetMouseState(&_x, &_y))
+	return int(_x), int(_y), _state
 }
 
-func GetRelativeMouseState(x, y *int) uint32 {
-	_x := (*C.int) (unsafe.Pointer(x))
-	_y := (*C.int) (unsafe.Pointer(y))
-	return (uint32) (C.SDL_GetRelativeMouseState(_x, _y))
+func GetRelativeMouseState() (x, y int, state uint32) {
+	var _x, _y C.int
+	_state := uint32(C.SDL_GetRelativeMouseState(&_x, &_y))
+	return int(_x), int(_y), _state
 }
 
 func (window *Window) WarpMouseInWindow(x, y int) {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	_x := (C.int) (x)
-	_y := (C.int) (y)
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	_x := (C.int)(x)
+	_y := (C.int)(y)
 	C.SDL_WarpMouseInWindow(_window, _x, _y)
 }
 
 func SetRelativeMouseMode(enabled bool) int {
-	_enabled := (C.SDL_bool) (Btoi(enabled))
-	return (int) (C.SDL_SetRelativeMouseMode(_enabled))
+	_enabled := (C.SDL_bool)(Btoi(enabled))
+	return (int)(C.SDL_SetRelativeMouseMode(_enabled))
 }
 
 func GetRelativeMouseMode() bool {
@@ -67,48 +67,48 @@ func GetRelativeMouseMode() bool {
 }
 
 func CreateCursor(data, mask *uint8, w, h, hot_x, hot_y int) *Cursor {
-	_data := (*C.Uint8) (unsafe.Pointer(data))
-	_mask := (*C.Uint8) (unsafe.Pointer(mask))
-	_w := (C.int) (w)
-	_h := (C.int) (h)
-	_hot_x := (C.int) (hot_x)
-	_hot_y := (C.int) (hot_y)
-	return (*Cursor) (C.SDL_CreateCursor(_data, _mask, _w, _h, _hot_x, _hot_y))
+	_data := (*C.Uint8)(unsafe.Pointer(data))
+	_mask := (*C.Uint8)(unsafe.Pointer(mask))
+	_w := (C.int)(w)
+	_h := (C.int)(h)
+	_hot_x := (C.int)(hot_x)
+	_hot_y := (C.int)(hot_y)
+	return (*Cursor)(C.SDL_CreateCursor(_data, _mask, _w, _h, _hot_x, _hot_y))
 }
 
 func CreateColorCursor(surface *Surface, hot_x, hot_y int) *Cursor {
-	_surface := (*C.SDL_Surface) (unsafe.Pointer(surface))
-	_hot_x := (C.int) (hot_x)
-	_hot_y := (C.int) (hot_y)
-	return (*Cursor) (C.SDL_CreateColorCursor(_surface, _hot_x, _hot_y))
+	_surface := (*C.SDL_Surface)(unsafe.Pointer(surface))
+	_hot_x := (C.int)(hot_x)
+	_hot_y := (C.int)(hot_y)
+	return (*Cursor)(C.SDL_CreateColorCursor(_surface, _hot_x, _hot_y))
 }
 
 func CreateSystemCursor(id SystemCursor) *Cursor {
-	_id := (C.SDL_SystemCursor) (id)
-	return (*Cursor) (C.SDL_CreateSystemCursor(_id))
+	_id := (C.SDL_SystemCursor)(id)
+	return (*Cursor)(C.SDL_CreateSystemCursor(_id))
 }
 
 func SetCursor(cursor *Cursor) {
-	_cursor := (*C.SDL_Cursor) (cursor)
+	_cursor := (*C.SDL_Cursor)(cursor)
 	C.SDL_SetCursor(_cursor)
 }
 
 func GetCursor() *Cursor {
-	return (*Cursor) (C.SDL_GetCursor())
+	return (*Cursor)(C.SDL_GetCursor())
 }
 
 func GetDefaultCursor() *Cursor {
-	return (*Cursor) (C.SDL_GetDefaultCursor())
+	return (*Cursor)(C.SDL_GetDefaultCursor())
 }
 
 func FreeCursor(cursor *Cursor) {
-	_cursor := (*C.SDL_Cursor) (cursor)
+	_cursor := (*C.SDL_Cursor)(cursor)
 	C.SDL_FreeCursor(_cursor)
 }
 
 func ShowCursor(toggle int) int {
-	_toggle := (C.int) (toggle)
-	return (int) (C.SDL_ShowCursor(_toggle))
+	_toggle := (C.int)(toggle)
+	return (int)(C.SDL_ShowCursor(_toggle))
 }
 
 func Button(flag uint32) uint32 {

--- a/sdl/sdl_render.go
+++ b/sdl/sdl_render.go
@@ -5,353 +5,355 @@ import "C"
 import "unsafe"
 
 const (
-	RENDERER_SOFTWARE		= 0x00000001
-	RENDERER_ACCELERATED		= 0x00000002
-	RENDERER_PRESENTVSYNC		= 0x00000004
-	RENDERER_TARGETTEXTURE		= 0x00000008
+	RENDERER_SOFTWARE      = 0x00000001
+	RENDERER_ACCELERATED   = 0x00000002
+	RENDERER_PRESENTVSYNC  = 0x00000004
+	RENDERER_TARGETTEXTURE = 0x00000008
 
-	TEXTUREACCESS_STATIC		= 0x00000001
-	TEXTUREACCESS_STREAMING		= 0x00000002
-	TEXTUREACCESS_TARGET		= 0x00000003
+	TEXTUREACCESS_STATIC    = 0x00000001
+	TEXTUREACCESS_STREAMING = 0x00000002
+	TEXTUREACCESS_TARGET    = 0x00000003
 
-	TEXTUREMODULATE_NONE		= 0x00000000
-	TEXTUREMODULATE_COLOR		= 0x00000001
-	TEXTUREMODULATE_ALPHA		= 0x00000002
+	TEXTUREMODULATE_NONE  = 0x00000000
+	TEXTUREMODULATE_COLOR = 0x00000001
+	TEXTUREMODULATE_ALPHA = 0x00000002
 
-	SDL_FLIP_NONE			= 0x00000000
-	SDL_FLIP_HORIZONTAL		= 0x00000001
-	SDL_FLIP_VERTICAL		= 0x00000002
+	SDL_FLIP_NONE       = 0x00000000
+	SDL_FLIP_HORIZONTAL = 0x00000001
+	SDL_FLIP_VERTICAL   = 0x00000002
 )
 
 type RendererInfo struct {
-	Name string
-	Flags uint32
+	Name              string
+	Flags             uint32
 	NumTextureFormats uint32
-	TextureFormats [16]int32
-	MaxTextureWidth int
-	MaxTextureHeight int
+	TextureFormats    [16]int32
+	MaxTextureWidth   int
+	MaxTextureHeight  int
 }
 
 func GetNumRenderDrivers() int {
-	return (int) (C.SDL_GetNumRenderDrivers())
+	return (int)(C.SDL_GetNumRenderDrivers())
 }
 
 func GetRenderDriverInfo(index int, info *RendererInfo) int {
-	_index := (C.int) (index)
-	_info := (*C.SDL_RendererInfo) (unsafe.Pointer(info))
-	return (int) (C.SDL_GetRenderDriverInfo(_index, _info))
+	_index := (C.int)(index)
+	_info := (*C.SDL_RendererInfo)(unsafe.Pointer(info))
+	return (int)(C.SDL_GetRenderDriverInfo(_index, _info))
 }
 
 func CreateWindowAndRenderer(w, h int, flags uint32) (*Window, *Renderer) {
 	var window *C.SDL_Window
 	var renderer *C.SDL_Renderer
 	C.SDL_CreateWindowAndRenderer(C.int(w), C.int(h), C.Uint32(flags), &window, &renderer)
-	return (*Window) (unsafe.Pointer(window)), (*Renderer) (unsafe.Pointer(renderer))
+	return (*Window)(unsafe.Pointer(window)), (*Renderer)(unsafe.Pointer(renderer))
 }
 
 func CreateRenderer(window *Window, index int, flags uint32) *Renderer {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	_index := (C.int) (index)
-	_flags := (C.Uint32) (flags)
-	return (*Renderer) (unsafe.Pointer(C.SDL_CreateRenderer(_window, _index, _flags)))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	_index := (C.int)(index)
+	_flags := (C.Uint32)(flags)
+	return (*Renderer)(unsafe.Pointer(C.SDL_CreateRenderer(_window, _index, _flags)))
 }
 
 func CreateSoftwareRenderer(surface *Surface) *Renderer {
-	_surface := (*C.SDL_Surface) (unsafe.Pointer(surface))
-	return (*Renderer) (unsafe.Pointer(C.SDL_CreateSoftwareRenderer(_surface)))
+	_surface := (*C.SDL_Surface)(unsafe.Pointer(surface))
+	return (*Renderer)(unsafe.Pointer(C.SDL_CreateSoftwareRenderer(_surface)))
 }
 
 func (window *Window) GetRenderer() *Renderer {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	return (*Renderer) (unsafe.Pointer(C.SDL_GetRenderer(_window)))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	return (*Renderer)(unsafe.Pointer(C.SDL_GetRenderer(_window)))
 }
 
 func (renderer *Renderer) GetRendererInfo(info *RendererInfo) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_info := (*C.SDL_RendererInfo) (unsafe.Pointer(info))
-	return (int) (C.SDL_GetRendererInfo(_renderer, _info))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_info := (*C.SDL_RendererInfo)(unsafe.Pointer(info))
+	return (int)(C.SDL_GetRendererInfo(_renderer, _info))
 }
 
-func (renderer *Renderer) GetRendererOutputSize(w *int, h *int) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_w := (*C.int) (unsafe.Pointer(w))
-	_h := (*C.int) (unsafe.Pointer(h))
-	return (int) (C.SDL_GetRendererOutputSize(_renderer, _w, _h))
+func (renderer *Renderer) GetRendererOutputSize() (w, h int, status int) {
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_w := (*C.int)(unsafe.Pointer(&w))
+	_h := (*C.int)(unsafe.Pointer(&h))
+	status = (int)(C.SDL_GetRendererOutputSize(_renderer, _w, _h))
+	return
 }
 
 func CreateTexture(renderer *Renderer, format uint32, access int, w int, h int) *Texture {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_format := (C.Uint32) (format)
-	_access := (C.int) (access)
-	_w := (C.int) (w)
-	_h := (C.int) (h)
-	return (*Texture) (unsafe.Pointer(C.SDL_CreateTexture(_renderer, _format, _access, _w, _h)))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_format := (C.Uint32)(format)
+	_access := (C.int)(access)
+	_w := (C.int)(w)
+	_h := (C.int)(h)
+	return (*Texture)(unsafe.Pointer(C.SDL_CreateTexture(_renderer, _format, _access, _w, _h)))
 }
 
 func (renderer *Renderer) CreateTextureFromSurface(surface *Surface) *Texture {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_surface := (*C.SDL_Surface) (unsafe.Pointer(surface))
-	return (*Texture) (unsafe.Pointer(C.SDL_CreateTextureFromSurface(_renderer, _surface)))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_surface := (*C.SDL_Surface)(unsafe.Pointer(surface))
+	return (*Texture)(unsafe.Pointer(C.SDL_CreateTextureFromSurface(_renderer, _surface)))
 }
 
 func QueryTexture(texture *Texture, format *uint32, access *int, w *int, h *int) int {
-	_texture := (*C.SDL_Texture) (unsafe.Pointer(texture))
-	_format := (*C.Uint32) (unsafe.Pointer(access))
-	_access := (*C.int) (unsafe.Pointer(access))
-	_w := (*C.int) (unsafe.Pointer(w))
-	_h := (*C.int) (unsafe.Pointer(h))
-	return (int) (C.SDL_QueryTexture(_texture, _format, _access, _w, _h))
+	_texture := (*C.SDL_Texture)(unsafe.Pointer(texture))
+	_format := (*C.Uint32)(unsafe.Pointer(access))
+	_access := (*C.int)(unsafe.Pointer(access))
+	_w := (*C.int)(unsafe.Pointer(w))
+	_h := (*C.int)(unsafe.Pointer(h))
+	return (int)(C.SDL_QueryTexture(_texture, _format, _access, _w, _h))
 }
 
 func (texture *Texture) SetColorMod(r uint8, g uint8, b uint8) int {
-	_texture := (*C.SDL_Texture) (unsafe.Pointer(texture))
-	_r := (C.Uint8) (r)
-	_g := (C.Uint8) (g)
-	_b := (C.Uint8) (b)
-	return (int) (C.SDL_SetTextureColorMod(_texture, _r, _g, _b))
+	_texture := (*C.SDL_Texture)(unsafe.Pointer(texture))
+	_r := (C.Uint8)(r)
+	_g := (C.Uint8)(g)
+	_b := (C.Uint8)(b)
+	return (int)(C.SDL_SetTextureColorMod(_texture, _r, _g, _b))
 }
 
 func (texture *Texture) SetAlphaMod(alpha uint8) int {
-	_texture := (*C.SDL_Texture) (unsafe.Pointer(texture))
-	_alpha := (C.Uint8) (alpha)
-	return (int) (C.SDL_SetTextureAlphaMod(_texture, _alpha))
+	_texture := (*C.SDL_Texture)(unsafe.Pointer(texture))
+	_alpha := (C.Uint8)(alpha)
+	return (int)(C.SDL_SetTextureAlphaMod(_texture, _alpha))
 }
 
 func (texture *Texture) SetBlendMode(blendMode uint32) int {
-	_texture := (*C.SDL_Texture) (unsafe.Pointer(texture))
-	_blendMode := (C.SDL_BlendMode) (C.Uint32(blendMode))
-	return (int) (C.SDL_SetTextureBlendMode(_texture, _blendMode))
+	_texture := (*C.SDL_Texture)(unsafe.Pointer(texture))
+	_blendMode := (C.SDL_BlendMode)(C.Uint32(blendMode))
+	return (int)(C.SDL_SetTextureBlendMode(_texture, _blendMode))
 }
 
-func (texture *Texture) GetBlendMode(blendMode *uint32) int {
-	_texture := (*C.SDL_Texture) (unsafe.Pointer(texture))
-	_blendMode := (*C.SDL_BlendMode) (unsafe.Pointer(blendMode))
-	return (int) (C.SDL_GetTextureBlendMode(_texture, _blendMode))
+func (texture *Texture) GetBlendMode() (blendMode uint32, status int) {
+	_texture := (*C.SDL_Texture)(unsafe.Pointer(texture))
+	_blendMode := (*C.SDL_BlendMode)(unsafe.Pointer(&blendMode))
+	status = (int)(C.SDL_GetTextureBlendMode(_texture, _blendMode))
+	return
 }
 
 func (texture *Texture) Update(rect *Rect, pixels unsafe.Pointer, pitch int) int {
-	_texture := (*C.SDL_Texture) (unsafe.Pointer(texture))
-	_rect := (*C.SDL_Rect) (unsafe.Pointer(rect))
-	_pitch := (C.int) (pitch)
-	return (int) (C.SDL_UpdateTexture(_texture, _rect, pixels, _pitch))
+	_texture := (*C.SDL_Texture)(unsafe.Pointer(texture))
+	_rect := (*C.SDL_Rect)(unsafe.Pointer(rect))
+	_pitch := (C.int)(pitch)
+	return (int)(C.SDL_UpdateTexture(_texture, _rect, pixels, _pitch))
 }
 
 func (texture *Texture) Lock(rect *Rect, pixels unsafe.Pointer, pitch *int) int {
-	_texture := (*C.SDL_Texture) (unsafe.Pointer(texture))
-	_rect := (*C.SDL_Rect) (unsafe.Pointer(rect))
-	_pitch := (*C.int) (unsafe.Pointer(pitch))
-	return (int) (C.SDL_LockTexture(_texture, _rect, &pixels, _pitch))
+	_texture := (*C.SDL_Texture)(unsafe.Pointer(texture))
+	_rect := (*C.SDL_Rect)(unsafe.Pointer(rect))
+	_pitch := (*C.int)(unsafe.Pointer(pitch))
+	return (int)(C.SDL_LockTexture(_texture, _rect, &pixels, _pitch))
 }
 
 func (texture *Texture) Unlock() {
-	_texture := (*C.SDL_Texture) (unsafe.Pointer(texture))
+	_texture := (*C.SDL_Texture)(unsafe.Pointer(texture))
 	(C.SDL_UnlockTexture(_texture))
 }
 
 func (renderer *Renderer) RenderTargetSupported() bool {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
 	return C.SDL_RenderTargetSupported(_renderer) != 0
 }
 
 func (renderer *Renderer) SetRenderTarget(texture *Texture) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_texture := (*C.SDL_Texture) (unsafe.Pointer(texture))
-	return (int) (C.SDL_SetRenderTarget(_renderer, _texture))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_texture := (*C.SDL_Texture)(unsafe.Pointer(texture))
+	return (int)(C.SDL_SetRenderTarget(_renderer, _texture))
 }
 
 func (renderer *Renderer) GetRenderTarget() *Texture {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	return (*Texture) (unsafe.Pointer(C.SDL_GetRenderTarget(_renderer)))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	return (*Texture)(unsafe.Pointer(C.SDL_GetRenderTarget(_renderer)))
 }
 
 func (renderer *Renderer) SetLogicalSize(w int, h int) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_w := (C.int) (w)
-	_h := (C.int) (h)
-	return (int) (C.SDL_RenderSetLogicalSize(_renderer, _w, _h))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_w := (C.int)(w)
+	_h := (C.int)(h)
+	return (int)(C.SDL_RenderSetLogicalSize(_renderer, _w, _h))
 }
 
 func (renderer *Renderer) SetViewport(rect *Rect) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_rect := (*C.SDL_Rect) (unsafe.Pointer(rect))
-	return (int) (C.SDL_RenderSetViewport(_renderer, _rect))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_rect := (*C.SDL_Rect)(unsafe.Pointer(rect))
+	return (int)(C.SDL_RenderSetViewport(_renderer, _rect))
 }
 
 func (renderer *Renderer) GetViewport(rect *Rect) {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_rect := (*C.SDL_Rect) (unsafe.Pointer(rect))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_rect := (*C.SDL_Rect)(unsafe.Pointer(rect))
 	C.SDL_RenderGetViewport(_renderer, _rect)
 }
 
 func (renderer *Renderer) SetClipRect(rect *Rect) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_rect := (*C.SDL_Rect) (unsafe.Pointer(rect))
-	return (int) (C.SDL_RenderSetClipRect(_renderer, _rect))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_rect := (*C.SDL_Rect)(unsafe.Pointer(rect))
+	return (int)(C.SDL_RenderSetClipRect(_renderer, _rect))
 }
 
 func (renderer *Renderer) GetClipRect(rect *Rect) {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_rect := (*C.SDL_Rect) (unsafe.Pointer(rect))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_rect := (*C.SDL_Rect)(unsafe.Pointer(rect))
 	C.SDL_RenderGetClipRect(_renderer, _rect)
 }
 
 func (renderer *Renderer) SetScale(scaleX, scaleY float32) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_scaleX := (C.float) (scaleX)
-	_scaleY := (C.float) (scaleY)
-	return (int) (C.SDL_RenderSetScale(_renderer, _scaleX, _scaleY))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_scaleX := (C.float)(scaleX)
+	_scaleY := (C.float)(scaleY)
+	return (int)(C.SDL_RenderSetScale(_renderer, _scaleX, _scaleY))
 }
 
-func (renderer *Renderer) GetScale(scaleX, scaleY *float32) {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_scaleX := (*C.float) (unsafe.Pointer(scaleX))
-	_scaleY := (*C.float) (unsafe.Pointer(scaleY))
+func (renderer *Renderer) GetScale() (scaleX, scaleY float32) {
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_scaleX := (*C.float)(unsafe.Pointer(&scaleX))
+	_scaleY := (*C.float)(unsafe.Pointer(&scaleY))
 	C.SDL_RenderGetScale(_renderer, _scaleX, _scaleY)
+	return
 }
 
 func (renderer *Renderer) SetDrawColor(r, g, b, a uint8) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_r := (C.Uint8) (r)
-	_g := (C.Uint8) (g)
-	_b := (C.Uint8) (b)
-	_a := (C.Uint8) (a)
-	return (int) (C.SDL_SetRenderDrawColor(_renderer, _r, _g, _b, _a))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_r := (C.Uint8)(r)
+	_g := (C.Uint8)(g)
+	_b := (C.Uint8)(b)
+	_a := (C.Uint8)(a)
+	return (int)(C.SDL_SetRenderDrawColor(_renderer, _r, _g, _b, _a))
 }
 
-func (renderer *Renderer) GetDrawColor(r, g, b, a *uint8) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_r := (*C.Uint8) (unsafe.Pointer(r))
-	_g := (*C.Uint8) (unsafe.Pointer(g))
-	_b := (*C.Uint8) (unsafe.Pointer(b))
-	_a := (*C.Uint8) (unsafe.Pointer(a))
-	return (int) (C.SDL_GetRenderDrawColor(_renderer, _r, _g, _b, _a))
+func (renderer *Renderer) GetDrawColor() (r, g, b, a uint8, status int) {
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_r := (*C.Uint8)(unsafe.Pointer(&r))
+	_g := (*C.Uint8)(unsafe.Pointer(&g))
+	_b := (*C.Uint8)(unsafe.Pointer(&b))
+	_a := (*C.Uint8)(unsafe.Pointer(&a))
+	status = (int)(C.SDL_GetRenderDrawColor(_renderer, _r, _g, _b, _a))
+	return
 }
 
 func (renderer *Renderer) SetDrawBlendMode(blendMode uint32) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_blendMode := (C.SDL_BlendMode) (blendMode)
-	return (int) (C.SDL_SetRenderDrawBlendMode(_renderer, _blendMode))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_blendMode := (C.SDL_BlendMode)(blendMode)
+	return (int)(C.SDL_SetRenderDrawBlendMode(_renderer, _blendMode))
 }
 
 func (renderer *Renderer) GetDrawBlendMode(blendMode *uint32) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_blendMode := (*C.SDL_BlendMode) (unsafe.Pointer(blendMode))
-	return (int) (C.SDL_GetRenderDrawBlendMode(_renderer, _blendMode))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_blendMode := (*C.SDL_BlendMode)(unsafe.Pointer(blendMode))
+	return (int)(C.SDL_GetRenderDrawBlendMode(_renderer, _blendMode))
 }
 
 func (renderer *Renderer) Clear() int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	return (int) (C.SDL_RenderClear(_renderer))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	return (int)(C.SDL_RenderClear(_renderer))
 }
 
 func (renderer *Renderer) DrawPoint(x, y int) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_x := (C.int) (x)
-	_y := (C.int) (y)
-	return (int) (C.SDL_RenderDrawPoint(_renderer, _x, _y))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_x := (C.int)(x)
+	_y := (C.int)(y)
+	return (int)(C.SDL_RenderDrawPoint(_renderer, _x, _y))
 }
 
 func (renderer *Renderer) DrawPoints(points []Point) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_points := (*C.SDL_Point) (unsafe.Pointer(&points[0]))
-	_count := (C.int) (len(points))
-	return (int) (C.SDL_RenderDrawPoints(_renderer, _points, _count))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_points := (*C.SDL_Point)(unsafe.Pointer(&points[0]))
+	_count := (C.int)(len(points))
+	return (int)(C.SDL_RenderDrawPoints(_renderer, _points, _count))
 }
 
 func (renderer *Renderer) DrawLine(x1, y1, x2, y2 int) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_x1 := (C.int) (x1)
-	_y1 := (C.int) (y1)
-	_x2 := (C.int) (x2)
-	_y2 := (C.int) (y2)
-	return (int) (C.SDL_RenderDrawLine(_renderer, _x1, _y1, _x2, _y2))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_x1 := (C.int)(x1)
+	_y1 := (C.int)(y1)
+	_x2 := (C.int)(x2)
+	_y2 := (C.int)(y2)
+	return (int)(C.SDL_RenderDrawLine(_renderer, _x1, _y1, _x2, _y2))
 }
 
 func (renderer *Renderer) DrawLines(points []Point) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_points := (*C.SDL_Point) (unsafe.Pointer(&points[0]))
-	_count := (C.int) (len(points))
-	return (int) (C.SDL_RenderDrawLines(_renderer, _points, _count))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_points := (*C.SDL_Point)(unsafe.Pointer(&points[0]))
+	_count := (C.int)(len(points))
+	return (int)(C.SDL_RenderDrawLines(_renderer, _points, _count))
 }
 
 func (renderer *Renderer) DrawRect(rect *Rect) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_rect := (*C.SDL_Rect) (unsafe.Pointer(rect))
-	return (int) (C.SDL_RenderDrawRect(_renderer, _rect))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_rect := (*C.SDL_Rect)(unsafe.Pointer(rect))
+	return (int)(C.SDL_RenderDrawRect(_renderer, _rect))
 }
 
 func (renderer *Renderer) DrawRects(rects []Rect) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_rects := (*C.SDL_Rect) (unsafe.Pointer(&rects[0]))
-	_count := (C.int) (len(rects))
-	return (int) (C.SDL_RenderDrawRects(_renderer, _rects, _count))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_rects := (*C.SDL_Rect)(unsafe.Pointer(&rects[0]))
+	_count := (C.int)(len(rects))
+	return (int)(C.SDL_RenderDrawRects(_renderer, _rects, _count))
 }
 
 func (renderer *Renderer) FillRect(rect *Rect) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_rect := (*C.SDL_Rect) (unsafe.Pointer(rect))
-	return (int) (C.SDL_RenderFillRect(_renderer, _rect))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_rect := (*C.SDL_Rect)(unsafe.Pointer(rect))
+	return (int)(C.SDL_RenderFillRect(_renderer, _rect))
 }
 
 func (renderer *Renderer) FillRects(rects []Rect) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_rects := (*C.SDL_Rect) (unsafe.Pointer(&rects[0]))
-	_count := (C.int) (len(rects))
-	return (int) (C.SDL_RenderFillRects(_renderer, _rects, _count))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_rects := (*C.SDL_Rect)(unsafe.Pointer(&rects[0]))
+	_count := (C.int)(len(rects))
+	return (int)(C.SDL_RenderFillRects(_renderer, _rects, _count))
 }
 
 func (renderer *Renderer) Copy(texture *Texture, srcrect, dstrect *Rect) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_texture := (*C.SDL_Texture) (unsafe.Pointer(texture))
-	_srcrect := (*C.SDL_Rect) (unsafe.Pointer(srcrect))
-	_dstrect := (*C.SDL_Rect) (unsafe.Pointer(dstrect))
-	return (int) (C.SDL_RenderCopy(_renderer, _texture, _srcrect, _dstrect))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_texture := (*C.SDL_Texture)(unsafe.Pointer(texture))
+	_srcrect := (*C.SDL_Rect)(unsafe.Pointer(srcrect))
+	_dstrect := (*C.SDL_Rect)(unsafe.Pointer(dstrect))
+	return (int)(C.SDL_RenderCopy(_renderer, _texture, _srcrect, _dstrect))
 }
 
 func (renderer *Renderer) CopyEx(texture *Texture, srcrect, dstrect *Rect, angle float64, center *Point, flip uint32) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_texture := (*C.SDL_Texture) (unsafe.Pointer(texture))
-	_srcrect := (*C.SDL_Rect) (unsafe.Pointer(srcrect))
-	_dstrect := (*C.SDL_Rect) (unsafe.Pointer(dstrect))
-	_angle := (C.double) (angle)
-	_center := (*C.SDL_Point) (unsafe.Pointer(center))
-	_flip := (C.SDL_RendererFlip) (flip)
-	return (int) (C.SDL_RenderCopyEx(_renderer, _texture, _srcrect, _dstrect, _angle, _center, _flip))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_texture := (*C.SDL_Texture)(unsafe.Pointer(texture))
+	_srcrect := (*C.SDL_Rect)(unsafe.Pointer(srcrect))
+	_dstrect := (*C.SDL_Rect)(unsafe.Pointer(dstrect))
+	_angle := (C.double)(angle)
+	_center := (*C.SDL_Point)(unsafe.Pointer(center))
+	_flip := (C.SDL_RendererFlip)(flip)
+	return (int)(C.SDL_RenderCopyEx(_renderer, _texture, _srcrect, _dstrect, _angle, _center, _flip))
 }
 
 func (renderer *Renderer) ReadPixels(rect *Rect, format uint32, pixels unsafe.Pointer, pitch int) int {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_rect := (*C.SDL_Rect) (unsafe.Pointer(rect))
-	_format := (C.Uint32) (format)
-	_pitch := (C.int) (pitch)
-	return (int) (C.SDL_RenderReadPixels(_renderer, _rect, _format, pixels, _pitch))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_rect := (*C.SDL_Rect)(unsafe.Pointer(rect))
+	_format := (C.Uint32)(format)
+	_pitch := (C.int)(pitch)
+	return (int)(C.SDL_RenderReadPixels(_renderer, _rect, _format, pixels, _pitch))
 }
 
 func (renderer *Renderer) Present() {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
 	C.SDL_RenderPresent(_renderer)
 }
 
 func (texture *Texture) Destroy() {
-	_texture := (*C.SDL_Texture) (unsafe.Pointer(texture))
+	_texture := (*C.SDL_Texture)(unsafe.Pointer(texture))
 	C.SDL_DestroyTexture(_texture)
 }
 
 func (renderer *Renderer) Destroy() {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
 	C.SDL_DestroyRenderer(_renderer)
 }
 
 func (texture *Texture) GL_BindTexture(texw, texh *float32) int {
-	_texture := (*C.SDL_Texture) (unsafe.Pointer(texture))
-	_texw := (*C.float) (unsafe.Pointer(texw))
-	_texh := (*C.float) (unsafe.Pointer(texh))
-	return (int) (C.SDL_GL_BindTexture(_texture, _texw, _texh))
+	_texture := (*C.SDL_Texture)(unsafe.Pointer(texture))
+	_texw := (*C.float)(unsafe.Pointer(texw))
+	_texh := (*C.float)(unsafe.Pointer(texh))
+	return (int)(C.SDL_GL_BindTexture(_texture, _texw, _texh))
 }
 
 func (texture *Texture) GL_UnbindTexture() int {
-	_texture := (*C.SDL_Texture) (unsafe.Pointer(texture))
-	return (int) (C.SDL_GL_UnbindTexture(_texture))
+	_texture := (*C.SDL_Texture)(unsafe.Pointer(texture))
+	return (int)(C.SDL_GL_UnbindTexture(_texture))
 }
-
-

--- a/sdl/sdl_rwops.go
+++ b/sdl/sdl_rwops.go
@@ -31,70 +31,72 @@ import "C"
 import "unsafe"
 
 const (
-	RW_SEEK_SET			= 0
-	RW_SEEK_CUR			= 1
-	RW_SEEK_END			= 2
+	RW_SEEK_SET = 0
+	RW_SEEK_CUR = 1
+	RW_SEEK_END = 2
 )
 
 type RWops C.SDL_RWops
 
 func RWFromFile(file, mode string) *RWops {
-	_file := (C.CString) (file)
-	_mode := (C.CString) (mode)
-	return (*RWops) (unsafe.Pointer(C.SDL_RWFromFile(_file, _mode)))
+	_file := C.CString(file)
+	defer C.free(unsafe.Pointer(_file))
+	_mode := C.CString(mode)
+	defer C.free(unsafe.Pointer(_mode))
+	return (*RWops)(unsafe.Pointer(C.SDL_RWFromFile(_file, _mode)))
 }
 
 func RWFromMem(mem unsafe.Pointer, size int) *RWops {
 	if mem == nil {
 		return nil
 	}
-	_size := (C.int) (size)
-	return (*RWops) (unsafe.Pointer(C.SDL_RWFromMem(mem, _size)))
+	_size := (C.int)(size)
+	return (*RWops)(unsafe.Pointer(C.SDL_RWFromMem(mem, _size)))
 }
 
 func AllocRW() *RWops {
-	return (*RWops) (unsafe.Pointer(C.SDL_AllocRW()))
+	return (*RWops)(unsafe.Pointer(C.SDL_AllocRW()))
 }
 
 func (area *RWops) FreeRW() {
 	if area == nil {
 		return
 	}
-	_area := (*C.SDL_RWops) (area)
+	_area := (*C.SDL_RWops)(area)
 	C.SDL_FreeRW(_area)
 }
 
 func (ctx *RWops) RWsize() int64 {
-	_ctx := (*C.SDL_RWops) (unsafe.Pointer(ctx))
-	return (int64) (C.RWsize(_ctx))
+	_ctx := (*C.SDL_RWops)(unsafe.Pointer(ctx))
+	return (int64)(C.RWsize(_ctx))
 }
 
 func (ctx *RWops) RWseek(offset int64, whence int) int64 {
 	if ctx == nil {
 		return -1
 	}
-	_ctx := (*C.SDL_RWops) (unsafe.Pointer(ctx))
-	_offset := (C.Sint64) (offset)
-	_whence := (C.int) (whence)
-	return (int64) (C.RWseek(_ctx, _offset, _whence))
+	_ctx := (*C.SDL_RWops)(unsafe.Pointer(ctx))
+	_offset := (C.Sint64)(offset)
+	_whence := (C.int)(whence)
+	return (int64)(C.RWseek(_ctx, _offset, _whence))
 }
 
 func (ctx *RWops) RWread(ptr unsafe.Pointer, size, maxnum uint) uint {
 	if ctx == nil {
 		return 0
 	}
-	_ctx := (*C.SDL_RWops) (unsafe.Pointer(ctx))
-	_size := (C.size_t) (size)
-	_maxnum := (C.size_t) (maxnum)
-	return (uint) (C.RWread(_ctx, ptr, _size, _maxnum))
+	_ctx := (*C.SDL_RWops)(unsafe.Pointer(ctx))
+	_size := (C.size_t)(size)
+	_maxnum := (C.size_t)(maxnum)
+	return (uint)(C.RWread(_ctx, ptr, _size, _maxnum))
 }
 
 func (ctx *RWops) RWtell() int64 {
 	if ctx == nil {
 		return 0
 	}
-	_ctx := (*C.SDL_RWops) (unsafe.Pointer(ctx))
-	return (int64) (C.RWseek(_ctx, 0, RW_SEEK_CUR))
+	_ctx := (*C.SDL_RWops)(unsafe.Pointer(ctx))
+	return (int64)(C.RWseek(_ctx, 0, RW_SEEK_CUR))
 }
 
 func (ctx *RWops) RWwrite(ptr unsafe.Pointer, size, num uint) uint {
@@ -104,135 +106,135 @@ func (ctx *RWops) RWwrite(ptr unsafe.Pointer, size, num uint) uint {
 	if ptr == nil {
 		return 0
 	}
-	_ctx := (*C.SDL_RWops) (unsafe.Pointer(ctx))
-	_size := (C.size_t) (size)
-	_num := (C.size_t) (num)
-	return (uint) (C.RWwrite(_ctx, ptr, _size, _num))
+	_ctx := (*C.SDL_RWops)(unsafe.Pointer(ctx))
+	_size := (C.size_t)(size)
+	_num := (C.size_t)(num)
+	return (uint)(C.RWwrite(_ctx, ptr, _size, _num))
 }
 
 func (ctx *RWops) RWclose() int {
 	if ctx == nil {
 		return 0
 	}
-	_ctx := (*C.SDL_RWops) (unsafe.Pointer(ctx))
-	return (int) (C.RWclose(_ctx))
+	_ctx := (*C.SDL_RWops)(unsafe.Pointer(ctx))
+	return (int)(C.RWclose(_ctx))
 }
 
 func (src *RWops) ReadU8() uint8 {
 	if src == nil {
 		return 0
 	}
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (uint8) (C.SDL_ReadU8(_src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (uint8)(C.SDL_ReadU8(_src))
 }
 
 func (src *RWops) ReadLE16() uint16 {
 	if src == nil {
 		return 0
 	}
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (uint16) (C.SDL_ReadLE16(_src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (uint16)(C.SDL_ReadLE16(_src))
 }
 
 func (src *RWops) ReadBE16() uint16 {
 	if src == nil {
 		return 0
 	}
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (uint16) (C.SDL_ReadBE16(_src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (uint16)(C.SDL_ReadBE16(_src))
 }
 
 func (src *RWops) ReadLE32() uint32 {
 	if src == nil {
 		return 0
 	}
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (uint32) (C.SDL_ReadLE32(_src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (uint32)(C.SDL_ReadLE32(_src))
 }
 
 func (src *RWops) ReadBE32() uint32 {
 	if src == nil {
 		return 0
 	}
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (uint32) (C.SDL_ReadBE32(_src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (uint32)(C.SDL_ReadBE32(_src))
 }
 
 func (src *RWops) ReadLE64() uint64 {
 	if src == nil {
 		return 0
 	}
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (uint64) (C.SDL_ReadLE64(_src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (uint64)(C.SDL_ReadLE64(_src))
 }
 
 func (src *RWops) ReadBE64() uint64 {
 	if src == nil {
 		return 0
 	}
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (uint64) (C.SDL_ReadBE64(_src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (uint64)(C.SDL_ReadBE64(_src))
 }
 
 func (dst *RWops) WriteU8(value uint8) uint {
 	if dst == nil {
 		return 0
 	}
-	_dst := (*C.SDL_RWops) (unsafe.Pointer(dst))
-	_value := (C.Uint8) (value)
-	return (uint) (C.SDL_WriteU8(_dst, _value))
+	_dst := (*C.SDL_RWops)(unsafe.Pointer(dst))
+	_value := (C.Uint8)(value)
+	return (uint)(C.SDL_WriteU8(_dst, _value))
 }
 
 func (dst *RWops) WriteLE16(value uint16) uint {
 	if dst == nil {
 		return 0
 	}
-	_dst := (*C.SDL_RWops) (unsafe.Pointer(dst))
-	_value := (C.Uint16) (value)
-	return (uint) (C.SDL_WriteLE16(_dst, _value))
+	_dst := (*C.SDL_RWops)(unsafe.Pointer(dst))
+	_value := (C.Uint16)(value)
+	return (uint)(C.SDL_WriteLE16(_dst, _value))
 }
 
 func (dst *RWops) WriteBE16(value uint16) uint {
 	if dst == nil {
 		return 0
 	}
-	_dst := (*C.SDL_RWops) (unsafe.Pointer(dst))
-	_value := (C.Uint16) (value)
-	return (uint) (C.SDL_WriteBE16(_dst, _value))
+	_dst := (*C.SDL_RWops)(unsafe.Pointer(dst))
+	_value := (C.Uint16)(value)
+	return (uint)(C.SDL_WriteBE16(_dst, _value))
 }
 
 func (dst *RWops) WriteLE32(value uint32) uint {
 	if dst == nil {
 		return 0
 	}
-	_dst := (*C.SDL_RWops) (unsafe.Pointer(dst))
-	_value := (C.Uint32) (value)
-	return (uint) (C.SDL_WriteLE32(_dst, _value))
+	_dst := (*C.SDL_RWops)(unsafe.Pointer(dst))
+	_value := (C.Uint32)(value)
+	return (uint)(C.SDL_WriteLE32(_dst, _value))
 }
 
 func (dst *RWops) WriteBE32(value uint32) uint {
 	if dst == nil {
 		return 0
 	}
-	_dst := (*C.SDL_RWops) (unsafe.Pointer(dst))
-	_value := (C.Uint32) (value)
-	return (uint) (C.SDL_WriteBE32(_dst, _value))
+	_dst := (*C.SDL_RWops)(unsafe.Pointer(dst))
+	_value := (C.Uint32)(value)
+	return (uint)(C.SDL_WriteBE32(_dst, _value))
 }
 
 func (dst *RWops) WriteLE64(value uint64) uint {
 	if dst == nil {
 		return 0
 	}
-	_dst := (*C.SDL_RWops) (unsafe.Pointer(dst))
-	_value := (C.Uint64) (value)
-	return (uint) (C.SDL_WriteLE64(_dst, _value))
+	_dst := (*C.SDL_RWops)(unsafe.Pointer(dst))
+	_value := (C.Uint64)(value)
+	return (uint)(C.SDL_WriteLE64(_dst, _value))
 }
 
 func (dst *RWops) WriteBE64(value uint64) uint {
 	if dst == nil {
 		return 0
 	}
-	_dst := (*C.SDL_RWops) (unsafe.Pointer(dst))
-	_value := (C.Uint64) (value)
-	return (uint) (C.SDL_WriteBE64(_dst, _value))
+	_dst := (*C.SDL_RWops)(unsafe.Pointer(dst))
+	_value := (C.Uint64)(value)
+	return (uint)(C.SDL_WriteBE64(_dst, _value))
 }

--- a/sdl/sdl_video.go
+++ b/sdl/sdl_video.go
@@ -5,74 +5,74 @@ import "C"
 import "unsafe"
 
 const (
-	WINDOW_FULLSCREEN		= 0x00000001
-	WINDOW_OPENGL			= 0x00000002
-	WINDOW_SHOWN			= 0x00000004
-	WINDOW_HIDDEN			= 0x00000008
-	WINDOW_BORDERLESS		= 0x00000010
-	WINDOW_RESIZABLE		= 0x00000020
-	WINDOW_MINIMIZED		= 0x00000040
-	WINDOW_MAXIMIZED		= 0x00000080
-	WINDOW_INPUT_GRABBED		= 0x00000100
-	WINDOW_INPUT_FOCUS		= 0x00000200
-	WINDOW_MOUSE_FOCUS		= 0x00000400
-	WINDOW_FULLSCREEN_DESKT		= WINDOW_FULLSCREEN | 0x00001000
-	WINDOW_FOREIGN			= 0x00000800
+	WINDOW_FULLSCREEN       = 0x00000001
+	WINDOW_OPENGL           = 0x00000002
+	WINDOW_SHOWN            = 0x00000004
+	WINDOW_HIDDEN           = 0x00000008
+	WINDOW_BORDERLESS       = 0x00000010
+	WINDOW_RESIZABLE        = 0x00000020
+	WINDOW_MINIMIZED        = 0x00000040
+	WINDOW_MAXIMIZED        = 0x00000080
+	WINDOW_INPUT_GRABBED    = 0x00000100
+	WINDOW_INPUT_FOCUS      = 0x00000200
+	WINDOW_MOUSE_FOCUS      = 0x00000400
+	WINDOW_FULLSCREEN_DESKT = WINDOW_FULLSCREEN | 0x00001000
+	WINDOW_FOREIGN          = 0x00000800
 )
 
 const (
-    WINDOWEVENT_NONE         = C.SDL_WINDOWEVENT_NONE
-    WINDOWEVENT_SHOWN        = C.SDL_WINDOWEVENT_SHOWN
-    WINDOWEVENT_HIDDEN       = C.SDL_WINDOWEVENT_HIDDEN
-    WINDOWEVENT_EXPOSED      = C.SDL_WINDOWEVENT_EXPOSED
-    WINDOWEVENT_MOVED        = C.SDL_WINDOWEVENT_MOVED
-    WINDOWEVENT_RESIZED      = C.SDL_WINDOWEVENT_RESIZED
-    WINDOWEVENT_SIZE_CHANGED = C.SDL_WINDOWEVENT_SIZE_CHANGED
-    WINDOWEVENT_MINIMIZED    = C.SDL_WINDOWEVENT_MINIMIZED
-    WINDOWEVENT_MAXIMIZED    = C.SDL_WINDOWEVENT_MAXIMIZED
-    WINDOWEVENT_RESTORED     = C.SDL_WINDOWEVENT_RESTORED
-    WINDOWEVENT_ENTER        = C.SDL_WINDOWEVENT_ENTER
-    WINDOWEVENT_LEAVE        = C.SDL_WINDOWEVENT_LEAVE
-    WINDOWEVENT_FOCUS_GAINED = C.SDL_WINDOWEVENT_FOCUS_GAINED
-    WINDOWEVENT_FOCUS_LOST   = C.SDL_WINDOWEVENT_FOCUS_LOST
-    WINDOWEVENT_CLOSE        = C.SDL_WINDOWEVENT_CLOSE
+	WINDOWEVENT_NONE         = C.SDL_WINDOWEVENT_NONE
+	WINDOWEVENT_SHOWN        = C.SDL_WINDOWEVENT_SHOWN
+	WINDOWEVENT_HIDDEN       = C.SDL_WINDOWEVENT_HIDDEN
+	WINDOWEVENT_EXPOSED      = C.SDL_WINDOWEVENT_EXPOSED
+	WINDOWEVENT_MOVED        = C.SDL_WINDOWEVENT_MOVED
+	WINDOWEVENT_RESIZED      = C.SDL_WINDOWEVENT_RESIZED
+	WINDOWEVENT_SIZE_CHANGED = C.SDL_WINDOWEVENT_SIZE_CHANGED
+	WINDOWEVENT_MINIMIZED    = C.SDL_WINDOWEVENT_MINIMIZED
+	WINDOWEVENT_MAXIMIZED    = C.SDL_WINDOWEVENT_MAXIMIZED
+	WINDOWEVENT_RESTORED     = C.SDL_WINDOWEVENT_RESTORED
+	WINDOWEVENT_ENTER        = C.SDL_WINDOWEVENT_ENTER
+	WINDOWEVENT_LEAVE        = C.SDL_WINDOWEVENT_LEAVE
+	WINDOWEVENT_FOCUS_GAINED = C.SDL_WINDOWEVENT_FOCUS_GAINED
+	WINDOWEVENT_FOCUS_LOST   = C.SDL_WINDOWEVENT_FOCUS_LOST
+	WINDOWEVENT_CLOSE        = C.SDL_WINDOWEVENT_CLOSE
 )
 
 const (
-	WINDOWPOS_UNDEFINED_MASK	= 0x1FFF0000
-	WINDOWPOS_UNDEFINED		= WINDOWPOS_UNDEFINED_MASK | 0
+	WINDOWPOS_UNDEFINED_MASK = 0x1FFF0000
+	WINDOWPOS_UNDEFINED      = WINDOWPOS_UNDEFINED_MASK | 0
 )
 
 const (
-	GL_RED_SIZE			= 0x00000000
-	GL_GREEN_SIZE			= 0x00000001
-	GL_BLUE_SIZE			= 0x00000002
-	GL_ALPHA_SIZE			= 0x00000003
-	GL_BUFFER_SIZE			= 0x00000004
-	GL_DOUBLEBUFFER			= 0x00000005
-	GL_DEPTH_SIZE			= 0x00000006
-	GL_STENCIL_SIZE			= 0x00000007
-	GL_ACCUM_RED_SIZE		= 0x00000008
-	GL_ACCUM_GREEN_SIZE		= 0x00000009
-	GL_ACCUM_BLUE_SIZE		= 0x0000000A
-	GL_ACCUM_ALPHA_SIZE		= 0x0000000B
-	GL_STEREO			= 0x0000000C
-	GL_MULTISAMPLEBUFFERS		= 0x0000000D
-	GL_MULTISAMPLESAMPLES		= 0x0000000E
-	GL_ACCELERATED_VISUAL		= 0x0000000F
-	GL_RETAINED_BACKING		= 0x00000010
-	GL_CONTEXT_MAJOR_VERSION	= 0x00000011
-	GL_CONTEXT_MINOR_VERSION	= 0x00000012
-	GL_CONTEXT_EGL			= 0x00000013
-	GL_CONTEXT_FLAGS		= 0x00000014
-	GL_CONTEXT_PROFILE_MASK		= 0x00000015
-	GL_SHARE_WITH_CURRENT_CONTEXT	= 0x00000016
+	GL_RED_SIZE                   = 0x00000000
+	GL_GREEN_SIZE                 = 0x00000001
+	GL_BLUE_SIZE                  = 0x00000002
+	GL_ALPHA_SIZE                 = 0x00000003
+	GL_BUFFER_SIZE                = 0x00000004
+	GL_DOUBLEBUFFER               = 0x00000005
+	GL_DEPTH_SIZE                 = 0x00000006
+	GL_STENCIL_SIZE               = 0x00000007
+	GL_ACCUM_RED_SIZE             = 0x00000008
+	GL_ACCUM_GREEN_SIZE           = 0x00000009
+	GL_ACCUM_BLUE_SIZE            = 0x0000000A
+	GL_ACCUM_ALPHA_SIZE           = 0x0000000B
+	GL_STEREO                     = 0x0000000C
+	GL_MULTISAMPLEBUFFERS         = 0x0000000D
+	GL_MULTISAMPLESAMPLES         = 0x0000000E
+	GL_ACCELERATED_VISUAL         = 0x0000000F
+	GL_RETAINED_BACKING           = 0x00000010
+	GL_CONTEXT_MAJOR_VERSION      = 0x00000011
+	GL_CONTEXT_MINOR_VERSION      = 0x00000012
+	GL_CONTEXT_EGL                = 0x00000013
+	GL_CONTEXT_FLAGS              = 0x00000014
+	GL_CONTEXT_PROFILE_MASK       = 0x00000015
+	GL_SHARE_WITH_CURRENT_CONTEXT = 0x00000016
 )
 
 const (
-	GL_CONTEXT_PROFILE_CORE           = 0x0001
-	GL_CONTEXT_PROFILE_COMPATIBILITY  = 0x0002
-	GL_CONTEXT_PROFILE_ES             = 0x0004
+	GL_CONTEXT_PROFILE_CORE          = 0x0001
+	GL_CONTEXT_PROFILE_COMPATIBILITY = 0x0002
+	GL_CONTEXT_PROFILE_ES            = 0x0004
 )
 
 const (
@@ -83,27 +83,29 @@ const (
 )
 
 type DisplayMode struct {
-	Format uint32
-	W int
-	H int
+	Format      uint32
+	W           int
+	H           int
 	RefreshRate int
-	DriverData unsafe.Pointer
+	DriverData  unsafe.Pointer
 }
 
 type Window C.SDL_Window
 type GLContext unsafe.Pointer
 
 func GetNumVideoDrivers() int {
-	return (int) (C.SDL_GetNumVideoDrivers())
+	return (int)(C.SDL_GetNumVideoDrivers())
 }
 
 func GetVideoDriver(index int) string {
-	_index := (C.int) (index)
-	return (string) (C.GoString(C.SDL_GetVideoDriver(_index)))
+	_index := (C.int)(index)
+	return (string)(C.GoString(C.SDL_GetVideoDriver(_index)))
 }
 
 func VideoInit(driverName string) int {
-	return (int) (C.SDL_VideoInit(C.CString(driverName)))
+	_driverName := C.CString(driverName)
+	defer C.free(unsafe.Pointer(_driverName))
+	return (int)(C.SDL_VideoInit(_driverName))
 }
 
 func VideoQuit() {
@@ -111,275 +113,273 @@ func VideoQuit() {
 }
 
 func GetCurrentVideoDriver() string {
-	return (string) (C.GoString(C.SDL_GetCurrentVideoDriver()))
+	return (string)(C.GoString(C.SDL_GetCurrentVideoDriver()))
 }
 
 func GetNumDisplayModes(displayIndex int) int {
-	_displayIndex := (C.int) (displayIndex)
-	return (int) (C.SDL_GetNumDisplayModes(_displayIndex))
+	_displayIndex := (C.int)(displayIndex)
+	return (int)(C.SDL_GetNumDisplayModes(_displayIndex))
 }
 
 func GetDisplayMode(displayIndex int, modeIndex int, mode *DisplayMode) int {
-	_displayIndex := (C.int) (displayIndex)
-	_modeIndex := (C.int) (modeIndex)
-	_mode := (*C.SDL_DisplayMode) (unsafe.Pointer(mode))
-	return (int) (C.SDL_GetDisplayMode(_displayIndex, _modeIndex, _mode))
+	_displayIndex := (C.int)(displayIndex)
+	_modeIndex := (C.int)(modeIndex)
+	_mode := (*C.SDL_DisplayMode)(unsafe.Pointer(mode))
+	return (int)(C.SDL_GetDisplayMode(_displayIndex, _modeIndex, _mode))
 }
 
 func GetDesktopDisplayMode(displayIndex int, mode *DisplayMode) int {
-	_displayIndex := (C.int) (displayIndex)
-	_mode := (*C.SDL_DisplayMode) (unsafe.Pointer(mode))
-	return (int) (C.SDL_GetDesktopDisplayMode(_displayIndex, _mode))
+	_displayIndex := (C.int)(displayIndex)
+	_mode := (*C.SDL_DisplayMode)(unsafe.Pointer(mode))
+	return (int)(C.SDL_GetDesktopDisplayMode(_displayIndex, _mode))
 }
 
 func GetCurrentDisplayMode(displayIndex int, mode *DisplayMode) int {
-	_displayIndex := (C.int) (displayIndex)
-	_mode := (*C.SDL_DisplayMode) (unsafe.Pointer(mode))
-	return (int) (C.SDL_GetCurrentDisplayMode(_displayIndex, _mode))
+	_displayIndex := (C.int)(displayIndex)
+	_mode := (*C.SDL_DisplayMode)(unsafe.Pointer(mode))
+	return (int)(C.SDL_GetCurrentDisplayMode(_displayIndex, _mode))
 }
 
 func GetClosestDisplayMode(displayIndex int, mode *DisplayMode, closest *DisplayMode) *DisplayMode {
-	_displayIndex := (C.int) (displayIndex)
-	_mode := (*C.SDL_DisplayMode) (unsafe.Pointer(mode))
-	_closest := (*C.SDL_DisplayMode) (unsafe.Pointer(closest))
-	return (*DisplayMode) (unsafe.Pointer((C.SDL_GetClosestDisplayMode(_displayIndex,
-									_mode, _closest))))
+	_displayIndex := (C.int)(displayIndex)
+	_mode := (*C.SDL_DisplayMode)(unsafe.Pointer(mode))
+	_closest := (*C.SDL_DisplayMode)(unsafe.Pointer(closest))
+	return (*DisplayMode)(unsafe.Pointer((C.SDL_GetClosestDisplayMode(_displayIndex,
+		_mode, _closest))))
 }
 
-func GetWindowDisplayIndex(window *Window) int {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	return (int) (C.SDL_GetWindowDisplayIndex(_window))
+func (window *Window) GetDisplayIndex() int {
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	return (int)(C.SDL_GetWindowDisplayIndex(_window))
 }
 
-func SetWindowDisplayMode(window *Window, mode *DisplayMode) int {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	_mode := (*C.SDL_DisplayMode) (unsafe.Pointer(mode))
-	return (int) (C.SDL_SetWindowDisplayMode(_window, _mode))
+func (window *Window) SetDisplayMode(mode *DisplayMode) int {
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	_mode := (*C.SDL_DisplayMode)(unsafe.Pointer(mode))
+	return (int)(C.SDL_SetWindowDisplayMode(_window, _mode))
 }
 
-func GetWindowDisplayMode(window *Window, mode *DisplayMode) int {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	_mode := (*C.SDL_DisplayMode) (unsafe.Pointer(mode))
-	return (int) (C.SDL_GetWindowDisplayMode(_window, _mode))
+func (window *Window) GetDisplayMode(mode *DisplayMode) int {
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	_mode := (*C.SDL_DisplayMode)(unsafe.Pointer(mode))
+	return (int)(C.SDL_GetWindowDisplayMode(_window, _mode))
 }
 
 func (window *Window) GetPixelFormat() uint32 {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	return (uint32) (C.SDL_GetWindowPixelFormat(_window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	return (uint32)(C.SDL_GetWindowPixelFormat(_window))
 }
 
 func CreateWindow(title string, x int, y int, w int, h int, flags uint32) *Window {
-	var window = C.SDL_CreateWindow(C.CString(title), C.int(x), C.int(y),
-					C.int(w), C.int(h), C.Uint32(flags))
-	return (*Window) (unsafe.Pointer(window))
+	_title := C.CString(title)
+	defer C.free(unsafe.Pointer(_title))
+	var window = C.SDL_CreateWindow(_title, C.int(x), C.int(y),
+		C.int(w), C.int(h), C.Uint32(flags))
+	return (*Window)(unsafe.Pointer(window))
 }
 
 func CreateWindowFrom(data unsafe.Pointer) *Window {
-	return (*Window) (unsafe.Pointer(C.SDL_CreateWindowFrom(data)))
+	return (*Window)(unsafe.Pointer(C.SDL_CreateWindowFrom(data)))
 }
 
 func (window *Window) Destroy() {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
 	C.SDL_DestroyWindow(_window)
 }
 
 func (window *Window) GetID() uint32 {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	return (uint32) (C.SDL_GetWindowID(_window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	return (uint32)(C.SDL_GetWindowID(_window))
 }
 
 func GetWindowFromID(id uint32) *Window {
-	_id := (C.Uint32) (id)
-	return (*Window) (unsafe.Pointer((C.SDL_GetWindowFromID(_id))))
+	_id := (C.Uint32)(id)
+	return (*Window)(unsafe.Pointer((C.SDL_GetWindowFromID(_id))))
 }
 
 func (window *Window) GetFlags() uint32 {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	return (uint32) (C.SDL_GetWindowFlags(_window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	return (uint32)(C.SDL_GetWindowFlags(_window))
 }
 
 func (window *Window) SetTitle(title string) {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	_title := (C.CString) (title)
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	_title := C.CString(title)
+	defer C.free(unsafe.Pointer(_title)) // sdl creates it's own copy, so this one can be freed
 	C.SDL_SetWindowTitle(_window, _title)
 }
 
 func (window *Window) GetTitle() string {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	return (string) (C.GoString(C.SDL_GetWindowTitle(_window)))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	return (string)(C.GoString(C.SDL_GetWindowTitle(_window)))
 }
 
 func (window *Window) SetIcon(icon *Surface) {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	_icon := (*C.SDL_Surface) (unsafe.Pointer(window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	_icon := (*C.SDL_Surface)(unsafe.Pointer(window))
 	C.SDL_SetWindowIcon(_window, _icon)
 }
 
 func (window *Window) SetData(name string, userdata unsafe.Pointer) unsafe.Pointer {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	_name := (C.CString) (name)
-	return (unsafe.Pointer) (C.SDL_SetWindowData(_window, _name, userdata))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	_name := C.CString(name)
+	defer C.free(unsafe.Pointer(_name))
+	return (unsafe.Pointer)(C.SDL_SetWindowData(_window, _name, userdata))
 }
 
-func (window *Window) GetData(name string, userdata unsafe.Pointer) unsafe.Pointer {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	_name := (C.CString) (name)
-	return (unsafe.Pointer) (C.SDL_GetWindowData(_window, _name))
+func (window *Window) GetData(name string) unsafe.Pointer {
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	_name := C.CString(name)
+	defer C.free(unsafe.Pointer(_name))
+	return (unsafe.Pointer)(C.SDL_GetWindowData(_window, _name))
 }
 
 func (window *Window) SetPosition(x int, y int) {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
 	C.SDL_SetWindowPosition(_window, C.int(x), C.int(y))
 }
 
-func (window *Window) GetPosition(x *int, y *int) {
-	var _x, _y C.int;
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
+func (window *Window) GetPosition() (x, y int) {
+	var _x, _y C.int
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
 	C.SDL_GetWindowPosition(_window, &_x, &_y)
-	*x = int(_x);
-	*y = int(_y);
+	return int(_x), int(_y)
 }
 
 func (window *Window) SetSize(w int, h int) {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
 	C.SDL_SetWindowSize(_window, C.int(w), C.int(h))
 }
 
-func (window *Window) GetSize(w *int, h *int) {
-	var _w, _h C.int;
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
+func (window *Window) GetSize() (w, h int) {
+	var _w, _h C.int
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
 	C.SDL_GetWindowSize(_window, &_w, &_h)
-	*w = int(_w);
-	*h = int(_h);
+	return int(_w), int(_h)
 }
 
 func (window *Window) SetMinimumSize(min_w int, min_h int) {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	_min_w := (C.int) (min_w)
-	_min_h := (C.int) (min_h)
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	_min_w := (C.int)(min_w)
+	_min_h := (C.int)(min_h)
 	C.SDL_SetWindowMinimumSize(_window, _min_w, _min_h)
 }
 
-func (window *Window) GetMinimumSize(w *int, h *int) {
-	var _w, _h C.int;
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
+func (window *Window) GetMinimumSize() (w, h int) {
+	var _w, _h C.int
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
 	C.SDL_GetWindowMinimumSize(_window, &_w, &_h)
-	*w = int(_w);
-	*h = int(_h);
+	return int(_w), int(_h)
 }
 
 func (window *Window) SetMaximumSize(max_w int, max_h int) {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	_max_w := (C.int) (max_w)
-	_max_h := (C.int) (max_h)
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	_max_w := (C.int)(max_w)
+	_max_h := (C.int)(max_h)
 	C.SDL_SetWindowMaximumSize(_window, _max_w, _max_h)
 }
 
-func (window *Window) GetMaximumSize(w *int, h *int) {
-	var _w, _h C.int;
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
+func (window *Window) GetMaximumSize() (w, h int) {
+	var _w, _h C.int
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
 	C.SDL_GetWindowMaximumSize(_window, &_w, &_h)
-	*w = int(_w);
-	*h = int(_h);
+	return int(_w), int(_h)
 }
 
 func (window *Window) SetBordered(bordered bool) {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	_bordered := (C.SDL_bool) (Btoi(bordered))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	_bordered := (C.SDL_bool)(Btoi(bordered))
 	C.SDL_SetWindowBordered(_window, _bordered)
 }
 
 func (window *Window) Show() {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
 	C.SDL_ShowWindow(_window)
 }
 
 func (window *Window) Hide() {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
 	C.SDL_HideWindow(_window)
 }
 
 func (window *Window) Raise() {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
 	C.SDL_RaiseWindow(_window)
 }
 
 func (window *Window) Maximize() {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
 	C.SDL_MaximizeWindow(_window)
 }
 
 func (window *Window) Minimize() {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
 	C.SDL_MinimizeWindow(_window)
 }
 
 func (window *Window) Restore() {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
 	C.SDL_RestoreWindow(_window)
 }
 
 func (window *Window) SetFullscreen(flags uint32) int {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	_flags := (C.Uint32) (flags)
-	return (int) (C.SDL_SetWindowFullscreen(_window, _flags))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	_flags := (C.Uint32)(flags)
+	return (int)(C.SDL_SetWindowFullscreen(_window, _flags))
 }
 
 func (window *Window) GetSurface() *Surface {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	return (*Surface) (unsafe.Pointer(C.SDL_GetWindowSurface(_window)))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	return (*Surface)(unsafe.Pointer(C.SDL_GetWindowSurface(_window)))
 }
 
 func (window *Window) UpdateSurface() int {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	return (int) (C.SDL_UpdateWindowSurface(_window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	return (int)(C.SDL_UpdateWindowSurface(_window))
 }
 
-func (window *Window) UpdateSurfaceRects(rects *Rect, numrects int) int {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	_rects := (*C.SDL_Rect) (unsafe.Pointer(rects))
-	_numrects := (C.int) (numrects)
-	return (int) (C.SDL_UpdateWindowSurfaceRects(_window, _rects, _numrects))
+func (window *Window) UpdateSurfaceRects(rects []Rect) int {
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	_rects := (*C.SDL_Rect)(unsafe.Pointer(&rects[0]))
+	_numrects := (C.int)(len(rects))
+	return (int)(C.SDL_UpdateWindowSurfaceRects(_window, _rects, _numrects))
 }
 
 func (window *Window) SetGrab(grabbed bool) {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	_grabbed := (C.SDL_bool) (Btoi(grabbed))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	_grabbed := (C.SDL_bool)(Btoi(grabbed))
 	C.SDL_SetWindowGrab(_window, _grabbed)
 }
 
 func (window *Window) GetGrab() bool {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
 	return C.SDL_GetWindowGrab(_window) != 0
 }
 
 func (window *Window) SetBrightness(brightness float32) int {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	_brightness := (C.float) (brightness)
-	return (int) (C.SDL_SetWindowBrightness(_window, _brightness))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	_brightness := (C.float)(brightness)
+	return (int)(C.SDL_SetWindowBrightness(_window, _brightness))
 }
 
 func (window *Window) GetBrightness() float32 {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	return (float32) (C.SDL_GetWindowBrightness(_window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	return (float32)(C.SDL_GetWindowBrightness(_window))
 }
 
 func (window *Window) SetGammaRamp(red, green, blue *uint16) int {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	_red := (*C.Uint16) (red)
-	_green := (*C.Uint16) (red)
-	_blue := (*C.Uint16) (blue)
-	return (int) (C.SDL_SetWindowGammaRamp(_window, _red, _green, _blue))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	_red := (*C.Uint16)(red)
+	_green := (*C.Uint16)(red)
+	_blue := (*C.Uint16)(blue)
+	return (int)(C.SDL_SetWindowGammaRamp(_window, _red, _green, _blue))
 }
 
-func (window *Window) GetGammaRamp(red, green, blue *uint16) int {
-	var _red, _green, _blue *C.Uint16
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	status := (int) (C.SDL_GetWindowGammaRamp(_window, _red, _green, _blue))
-	*red = (uint16) (*_red)
-	*green = (uint16) (*_green)
-	*blue = (uint16) (*_blue)
-	return status;
+func (window *Window) GetGammaRamp() (red, green, blue uint16, status int) {
+	var _red, _green, _blue C.Uint16
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	_status := (int)(C.SDL_GetWindowGammaRamp(_window, &_red, &_green, &_blue))
+	return uint16(_red), uint16(_green), uint16(_blue), _status
 }
 
 func IsScreenSaverEnabled() bool {
@@ -395,13 +395,15 @@ func DisableScreenSaver() {
 }
 
 func GL_LoadLibrary(path string) int {
-	_path := (C.CString) (path)
-	return (int) (C.SDL_GL_LoadLibrary(_path))
+	_path := C.CString(path)
+	defer C.free(unsafe.Pointer(_path))
+	return (int)(C.SDL_GL_LoadLibrary(_path))
 }
 
 func GL_GetProcAddress(proc string) unsafe.Pointer {
-	_proc := (C.CString) (proc)
-	return (unsafe.Pointer) (C.SDL_GL_GetProcAddress(_proc))
+	_proc := C.CString(proc)
+	defer C.free(unsafe.Pointer(_proc))
+	return (unsafe.Pointer)(C.SDL_GL_GetProcAddress(_proc))
 }
 
 func GL_UnloadLibrary() {
@@ -409,48 +411,50 @@ func GL_UnloadLibrary() {
 }
 
 func GL_ExtensionSupported(extension string) bool {
-	_extension := (C.CString) (extension)
+	_extension := C.CString(extension)
+	defer C.free(unsafe.Pointer(_extension))
 	return C.SDL_GL_ExtensionSupported(_extension) != 0
 }
 
 func GL_SetAttribute(attribute uint32, value int) int {
-	_attribute := (C.SDL_GLattr) (attribute)
-	_value := (C.int) (value)
-	return (int) (C.SDL_GL_SetAttribute(_attribute, _value))
+	_attribute := (C.SDL_GLattr)(attribute)
+	_value := (C.int)(value)
+	return (int)(C.SDL_GL_SetAttribute(_attribute, _value))
 }
 
-func GL_GetAttribute(attribute uint32, value *int) int {
-	_attribute := (C.SDL_GLattr) (attribute)
-	_value := (*C.int) (unsafe.Pointer(value))
-	return (int) (C.SDL_GL_GetAttribute(_attribute, _value))
+func GL_GetAttribute(attribute uint32) (value int, status int) {
+	_attribute := (C.SDL_GLattr)(attribute)
+	var _value, _status C.int
+	_status = (C.SDL_GL_GetAttribute(_attribute, &_value))
+	return int(_status), int(_value)
 }
 
 func GL_CreateContext(window *Window) GLContext {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	return (GLContext) (C.SDL_GL_CreateContext(_window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	return (GLContext)(C.SDL_GL_CreateContext(_window))
 }
 
 func GL_MakeCurrent(window *Window, glcontext GLContext) int {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
-	_glcontext := (C.SDL_GLContext) (glcontext)
-	return (int) (C.SDL_GL_MakeCurrent(_window, _glcontext))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
+	_glcontext := (C.SDL_GLContext)(glcontext)
+	return (int)(C.SDL_GL_MakeCurrent(_window, _glcontext))
 }
 
 func GL_SetSwapInterval(interval int) int {
-	_interval := (C.int) (interval)
-	return (int) (C.SDL_GL_SetSwapInterval(_interval))
+	_interval := (C.int)(interval)
+	return (int)(C.SDL_GL_SetSwapInterval(_interval))
 }
 
 func GL_GetSwapInterval() int {
-	return (int) (C.SDL_GL_GetSwapInterval())
+	return (int)(C.SDL_GL_GetSwapInterval())
 }
 
 func GL_SwapWindow(window *Window) {
-	_window := (*C.SDL_Window) (unsafe.Pointer(window))
+	_window := (*C.SDL_Window)(unsafe.Pointer(window))
 	C.SDL_GL_SwapWindow(_window)
 }
 
 func GL_DeleteContext(context GLContext) {
-	_context := (C.SDL_GLContext) (context)
+	_context := (C.SDL_GLContext)(context)
 	C.SDL_GL_DeleteContext(_context)
 }

--- a/sdl_image/sdl_image.go
+++ b/sdl_image/sdl_image.go
@@ -7,18 +7,18 @@ import "unsafe"
 import "github.com/jackyb/go-sdl2/sdl"
 
 const (
-	INIT_JPG = 0x00000001
-	INIT_PNG = 0x00000002
-	INIT_TIF = 0x00000004
+	INIT_JPG  = 0x00000001
+	INIT_PNG  = 0x00000002
+	INIT_TIF  = 0x00000004
 	INIT_WEBP = 0x00000008
 )
 
 func LinkedVersion() *sdl.Version {
-	return (*sdl.Version) (unsafe.Pointer(C.IMG_Linked_Version()))
+	return (*sdl.Version)(unsafe.Pointer(C.IMG_Linked_Version()))
 }
 
 func Init(flags int) int {
-	_flags := (C.int) (flags)
+	_flags := (C.int)(flags)
 	return int(C.IMG_Init(_flags))
 }
 
@@ -27,194 +27,200 @@ func Quit() {
 }
 
 func LoadTyped_RW(src *sdl.RWops, freesrc int, type_ string) *sdl.Surface {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	_freesrc := (C.int) (freesrc)
-	_type := (C.CString) (type_)
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_LoadTyped_RW(_src, _freesrc, _type)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	_freesrc := (C.int)(freesrc)
+	_type := C.CString(type_)
+	defer C.free(unsafe.Pointer(_type))
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_LoadTyped_RW(_src, _freesrc, _type)))
 }
 
 func Load(file string) *sdl.Surface {
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_Load(C.CString(file))))
+	_file := C.CString(file)
+	defer C.free(unsafe.Pointer(_file))
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_Load(_file)))
 }
 
 func Load_RW(src *sdl.RWops, freesrc int) *sdl.Surface {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	_freesrc := (C.int) (freesrc)
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_Load_RW(_src, _freesrc)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	_freesrc := (C.int)(freesrc)
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_Load_RW(_src, _freesrc)))
 }
 
 func LoadTexture(renderer *sdl.Renderer, file string) *sdl.Texture {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_file := (C.CString) (file)
-	return (*sdl.Texture) (unsafe.Pointer(C.IMG_LoadTexture(_renderer, _file)))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_file := C.CString(file)
+	defer C.free(unsafe.Pointer(_file))
+	return (*sdl.Texture)(unsafe.Pointer(C.IMG_LoadTexture(_renderer, _file)))
 }
 
 func LoadTexture_RW(renderer *sdl.Renderer, src *sdl.RWops, freesrc int) *sdl.Texture {
-	_renderer := (*C.SDL_Renderer) (unsafe.Pointer(renderer))
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	_freesrc := (C.int) (freesrc)
-	return (*sdl.Texture) (unsafe.Pointer(C.IMG_LoadTexture_RW(_renderer, _src, _freesrc)))
+	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	_freesrc := (C.int)(freesrc)
+	return (*sdl.Texture)(unsafe.Pointer(C.IMG_LoadTexture_RW(_renderer, _src, _freesrc)))
 }
 
 func IsICO(src *sdl.RWops) bool {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
 	return int(C.IMG_isICO(_src)) > 0
 }
 
 func IsCUR(src *sdl.RWops) bool {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
 	return int(C.IMG_isCUR(_src)) > 0
 }
 
 func IsBMP(src *sdl.RWops) bool {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
 	return int(C.IMG_isBMP(_src)) > 0
 }
 
 func IsGIF(src *sdl.RWops) bool {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
 	return int(C.IMG_isGIF(_src)) > 0
 }
 
 func IsJPG(src *sdl.RWops) bool {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
 	return int(C.IMG_isJPG(_src)) > 0
 }
 
 func IsLBM(src *sdl.RWops) bool {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
 	return int(C.IMG_isLBM(_src)) > 0
 }
 
 func IsPCX(src *sdl.RWops) bool {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
 	return int(C.IMG_isPCX(_src)) > 0
 }
 
 func IsPNG(src *sdl.RWops) bool {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
 	return int(C.IMG_isPNG(_src)) > 0
 }
 
 func IsPNM(src *sdl.RWops) bool {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
 	return int(C.IMG_isPNM(_src)) > 0
 }
 
 func IsTIF(src *sdl.RWops) bool {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
 	return int(C.IMG_isTIF(_src)) > 0
 }
 
 func IsXCF(src *sdl.RWops) bool {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
 	return int(C.IMG_isXCF(_src)) > 0
 }
 
 func IsXPM(src *sdl.RWops) bool {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
 	return int(C.IMG_isXPM(_src)) > 0
 }
 
 func IsXV(src *sdl.RWops) bool {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
 	return int(C.IMG_isXV(_src)) > 0
 }
 
 func IsWEBP(src *sdl.RWops) bool {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
 	return int(C.IMG_isWEBP(_src)) > 0
 }
 
 func LoadICO_RW(src *sdl.RWops) *sdl.Surface {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_LoadICO_RW(_src)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_LoadICO_RW(_src)))
 }
 
 func LoadCUR_RW(src *sdl.RWops) *sdl.Surface {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_LoadCUR_RW(_src)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_LoadCUR_RW(_src)))
 }
 
 func LoadBMP_RW(src *sdl.RWops) *sdl.Surface {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_LoadBMP_RW(_src)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_LoadBMP_RW(_src)))
 }
 
 func LoadGIF_RW(src *sdl.RWops) *sdl.Surface {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_LoadGIF_RW(_src)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_LoadGIF_RW(_src)))
 }
 
 func LoadJPG_RW(src *sdl.RWops) *sdl.Surface {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_LoadJPG_RW(_src)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_LoadJPG_RW(_src)))
 }
 
 func LoadLBM_RW(src *sdl.RWops) *sdl.Surface {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_LoadLBM_RW(_src)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_LoadLBM_RW(_src)))
 }
 
 func LoadPCX_RW(src *sdl.RWops) *sdl.Surface {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_LoadPCX_RW(_src)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_LoadPCX_RW(_src)))
 }
 
 func LoadPNG_RW(src *sdl.RWops) *sdl.Surface {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_LoadPNG_RW(_src)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_LoadPNG_RW(_src)))
 }
 
 func LoadPNM_RW(src *sdl.RWops) *sdl.Surface {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_LoadPNM_RW(_src)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_LoadPNM_RW(_src)))
 }
 
 func LoadTGA_RW(src *sdl.RWops) *sdl.Surface {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_LoadTGA_RW(_src)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_LoadTGA_RW(_src)))
 }
 
 func LoadTIF_RW(src *sdl.RWops) *sdl.Surface {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_LoadTIF_RW(_src)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_LoadTIF_RW(_src)))
 }
 
 func LoadXCF_RW(src *sdl.RWops) *sdl.Surface {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_LoadXCF_RW(_src)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_LoadXCF_RW(_src)))
 }
 
 func LoadXPM_RW(src *sdl.RWops) *sdl.Surface {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_LoadXPM_RW(_src)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_LoadXPM_RW(_src)))
 }
 
 func LoadXV_RW(src *sdl.RWops) *sdl.Surface {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_LoadXV_RW(_src)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_LoadXV_RW(_src)))
 }
 
 func LoadWEBP_RW(src *sdl.RWops) *sdl.Surface {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_LoadWEBP_RW(_src)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_LoadWEBP_RW(_src)))
 }
 
 func ReadXPMFromArray(xpm string) *sdl.Surface {
-	_xpm := (C.CString) (xpm)
-	return (*sdl.Surface) (unsafe.Pointer(C.IMG_ReadXPMFromArray(&_xpm)))
+	_xpm := C.CString(xpm)
+	C.free(unsafe.Pointer(_xpm))
+	return (*sdl.Surface)(unsafe.Pointer(C.IMG_ReadXPMFromArray(&_xpm)))
 }
 
 func SavePNG(surface *sdl.Surface, file string) int {
-	_surface := (*C.SDL_Surface) (unsafe.Pointer(surface))
-	_file := (C.CString) (file)
+	_surface := (*C.SDL_Surface)(unsafe.Pointer(surface))
+	_file := C.CString(file)
+	C.free(unsafe.Pointer(_file))
 	return int(C.IMG_SavePNG(_surface, _file))
 }
 
 func SavePNG_RW(surface *sdl.Surface, dst *sdl.RWops, freedst int) int {
-	_surface := (*C.SDL_Surface) (unsafe.Pointer(surface))
-	_dst := (*C.SDL_RWops) (unsafe.Pointer(dst))
-	_freedst := (C.int) (freedst)
+	_surface := (*C.SDL_Surface)(unsafe.Pointer(surface))
+	_dst := (*C.SDL_RWops)(unsafe.Pointer(dst))
+	_freedst := (C.int)(freedst)
 	return int(C.IMG_SavePNG_RW(_surface, _dst, _freedst))
 }

--- a/sdl_mixer/sdl_mixer.go
+++ b/sdl_mixer/sdl_mixer.go
@@ -8,9 +8,9 @@ import "github.com/jackyb/go-sdl2/sdl"
 
 type Chunk struct {
 	Allocated int32
-	Buf *uint8
-	Len uint32
-	Volume uint8
+	Buf       *uint8
+	Len       uint32
+	Volume    uint8
 }
 
 const (
@@ -49,224 +49,227 @@ type MusicType int
 type Fading int
 
 func OpenAudio(frequency int, format uint16, channels, chunksize int) bool {
-	_frequency := (C.int) (frequency)
-	_format := (C.Uint16) (format)
-	_channels := (C.int) (channels)
-	_chunksize := (C.int) (chunksize)
+	_frequency := (C.int)(frequency)
+	_format := (C.Uint16)(format)
+	_channels := (C.int)(channels)
+	_chunksize := (C.int)(chunksize)
 	return int(C.Mix_OpenAudio(_frequency, _format, _channels, _chunksize)) == 0
 }
 
 func AllocateChannels(numchans int) bool {
-	_numchans := (C.int) (numchans)
+	_numchans := (C.int)(numchans)
 	return int(C.Mix_AllocateChannels(_numchans)) == 0
 }
 
 func QuerySpec(frequency *int, format *uint16, channels *int) bool {
-	_frequency := (*C.int) (unsafe.Pointer(frequency))
-	_format := (*C.Uint16) (unsafe.Pointer(format))
-	_channels := (*C.int) (unsafe.Pointer(channels))
+	_frequency := (*C.int)(unsafe.Pointer(frequency))
+	_format := (*C.Uint16)(unsafe.Pointer(format))
+	_channels := (*C.int)(unsafe.Pointer(channels))
 	return int(C.Mix_QuerySpec(_frequency, _format, _channels)) > 0
 }
 
 func LoadWAV_RW(src *sdl.RWops, freesrc int) *Chunk {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	_freesrc := (C.int) (freesrc)
-	return (*Chunk) (unsafe.Pointer(C.Mix_LoadWAV_RW(_src, _freesrc)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	_freesrc := (C.int)(freesrc)
+	return (*Chunk)(unsafe.Pointer(C.Mix_LoadWAV_RW(_src, _freesrc)))
 }
 
 func LoadWAV(file string) *Chunk {
-	_file := (C.CString) (file)
-	return (*Chunk) (unsafe.Pointer(C.Mix_LoadWAV_RW(C.SDL_RWFromFile(_file,
-			C.CString("rb")), 1)))
+	_file := C.CString(file)
+	defer C.free(unsafe.Pointer(_file))
+	_rb := C.CString("rb")
+	defer C.free(unsafe.Pointer(_rb))
+	return (*Chunk)(unsafe.Pointer(C.Mix_LoadWAV_RW(C.SDL_RWFromFile(_file, _rb), 1)))
 }
 
 func LoadMUS(file string) *Music {
-	_file := (C.CString) (file)
-	return (*Music) (unsafe.Pointer(C.Mix_LoadMUS(_file)))
+	_file := C.CString(file)
+	defer C.free(unsafe.Pointer(_file))
+	return (*Music)(unsafe.Pointer(C.Mix_LoadMUS(_file)))
 }
 
 func LoadMUS_RW(src *sdl.RWops, freesrc int) *Music {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	_freesrc := (C.int) (freesrc)
-	return (*Music) (unsafe.Pointer(C.Mix_LoadMUS_RW(_src, _freesrc)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	_freesrc := (C.int)(freesrc)
+	return (*Music)(unsafe.Pointer(C.Mix_LoadMUS_RW(_src, _freesrc)))
 }
 
 func LoadMUSType_RW(src *sdl.RWops, type_ MusicType, freesrc int) *Music {
-	_src := (*C.SDL_RWops) (unsafe.Pointer(src))
-	_type := (C.Mix_MusicType) (type_)
-	_freesrc := (C.int) (freesrc)
-	return (*Music) (unsafe.Pointer(C.Mix_LoadMUSType_RW(_src, _type,
-			_freesrc)))
+	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
+	_type := (C.Mix_MusicType)(type_)
+	_freesrc := (C.int)(freesrc)
+	return (*Music)(unsafe.Pointer(C.Mix_LoadMUSType_RW(_src, _type,
+		_freesrc)))
 }
 
 func QuickLoad_WAV(mem *uint8) *Chunk {
-	_mem := (*C.Uint8) (mem)
-	return (*Chunk) (unsafe.Pointer(C.Mix_QuickLoad_WAV(_mem)))
+	_mem := (*C.Uint8)(mem)
+	return (*Chunk)(unsafe.Pointer(C.Mix_QuickLoad_WAV(_mem)))
 }
 
 func QuickLoad_RAW(mem *uint8, len_ uint32) *Chunk {
-	_mem := (*C.Uint8) (mem)
-	_len := (C.Uint32) (len_)
-	return (*Chunk) (unsafe.Pointer(C.Mix_QuickLoad_RAW(_mem, _len)))
+	_mem := (*C.Uint8)(mem)
+	_len := (C.Uint32)(len_)
+	return (*Chunk)(unsafe.Pointer(C.Mix_QuickLoad_RAW(_mem, _len)))
 }
 
 func (chunk *Chunk) Free() {
-	_chunk := (*C.Mix_Chunk) (unsafe.Pointer(chunk))
+	_chunk := (*C.Mix_Chunk)(unsafe.Pointer(chunk))
 	C.Mix_FreeChunk(_chunk)
 }
 
 func (music *Music) Free() {
-	_music := (*C.Mix_Music) (unsafe.Pointer(music))
+	_music := (*C.Mix_Music)(unsafe.Pointer(music))
 	C.Mix_FreeMusic(_music)
 }
 
 func (music *Music) Type() MusicType {
-	_music := (*C.Mix_Music) (unsafe.Pointer(music))
-	return (MusicType) (C.Mix_GetMusicType(_music))
+	_music := (*C.Mix_Music)(unsafe.Pointer(music))
+	return (MusicType)(C.Mix_GetMusicType(_music))
 }
 
 func SetPanning(channel int, left, right uint8) bool {
-	_channel := (C.int) (channel)
-	_left := (C.Uint8) (left)
-	_right := (C.Uint8) (right)
+	_channel := (C.int)(channel)
+	_left := (C.Uint8)(left)
+	_right := (C.Uint8)(right)
 	return int(C.Mix_SetPanning(_channel, _left, _right)) == 0
 }
 
 func SetPosition(channel int, angle int16, distance uint8) bool {
-	_channel := (C.int) (channel)
-	_angle := (C.Sint16) (angle)
-	_distance := (C.Uint8) (distance)
+	_channel := (C.int)(channel)
+	_angle := (C.Sint16)(angle)
+	_distance := (C.Uint8)(distance)
 	return int(C.Mix_SetPosition(_channel, _angle, _distance)) == 0
 }
 
 func SetDistance(channel int, distance uint8) bool {
-	_channel := (C.int) (channel)
-	_distance := (C.Uint8) (distance)
+	_channel := (C.int)(channel)
+	_distance := (C.Uint8)(distance)
 	return int(C.Mix_SetDistance(_channel, _distance)) == 0
 }
 
 func SetReverseStereo(channel int, flip int) bool {
-	_channel := (C.int) (channel)
-	_flip := (C.int) (flip)
+	_channel := (C.int)(channel)
+	_flip := (C.int)(flip)
 	return int(C.Mix_SetReverseStereo(_channel, _flip)) == 0
 }
 
 func ReserveChannels(num int) int {
-	_num := (C.int) (num)
-	return (int) (C.Mix_ReserveChannels(_num))
+	_num := (C.int)(num)
+	return (int)(C.Mix_ReserveChannels(_num))
 }
 
 func GroupChannel(which, tag int) bool {
-	_which := (C.int) (which)
-	_tag := (C.int) (tag)
+	_which := (C.int)(which)
+	_tag := (C.int)(tag)
 	return int(C.Mix_GroupChannel(_which, _tag)) > 0
 }
 
 func GroupChannels(from, to, tag int) bool {
-	_from := (C.int) (from)
-	_to := (C.int) (to)
-	_tag := (C.int) (tag)
+	_from := (C.int)(from)
+	_to := (C.int)(to)
+	_tag := (C.int)(tag)
 	return int(C.Mix_GroupChannels(_from, _to, _tag)) > 0
 }
 
 func GroupAvailable(tag int) int {
-	_tag := (C.int) (tag)
-	return (int) (C.Mix_GroupAvailable(_tag))
+	_tag := (C.int)(tag)
+	return (int)(C.Mix_GroupAvailable(_tag))
 }
 
 func GroupCount(tag int) int {
-	_tag := (C.int) (tag)
-	return (int) (C.Mix_GroupCount(_tag))
+	_tag := (C.int)(tag)
+	return (int)(C.Mix_GroupCount(_tag))
 }
 
 func GroupOldest(tag int) int {
-	_tag := (C.int) (tag)
-	return (int) (C.Mix_GroupOldest(_tag))
+	_tag := (C.int)(tag)
+	return (int)(C.Mix_GroupOldest(_tag))
 }
 
 func GroupNewer(tag int) int {
-	_tag := (C.int) (tag)
-	return (int) (C.Mix_GroupNewer(_tag))
+	_tag := (C.int)(tag)
+	return (int)(C.Mix_GroupNewer(_tag))
 }
 
 func (chunk *Chunk) PlayTimed(channel, loops, ticks int) bool {
-	_channel := (C.int) (channel)
-	_chunk := (*C.Mix_Chunk) (unsafe.Pointer(chunk))
-	_loops := (C.int) (loops)
-	_ticks := (C.int) (ticks)
+	_channel := (C.int)(channel)
+	_chunk := (*C.Mix_Chunk)(unsafe.Pointer(chunk))
+	_loops := (C.int)(loops)
+	_ticks := (C.int)(ticks)
 	return int(C.Mix_PlayChannelTimed(_channel, _chunk, _loops, _ticks)) == 0
 }
 
 func (chunk *Chunk) PlayChannel(channel, loops int) bool {
-	_channel := (C.int) (channel)
-	_chunk := (*C.Mix_Chunk) (unsafe.Pointer(chunk))
-	_loops := (C.int) (loops)
+	_channel := (C.int)(channel)
+	_chunk := (*C.Mix_Chunk)(unsafe.Pointer(chunk))
+	_loops := (C.int)(loops)
 	return int(C.Mix_PlayChannelTimed(_channel, _chunk, _loops, -1)) == 0
 }
 
 func (music *Music) Play(loops int) bool {
-	_music := (*C.Mix_Music) (unsafe.Pointer(music))
-	_loops := (C.int) (loops)
+	_music := (*C.Mix_Music)(unsafe.Pointer(music))
+	_loops := (C.int)(loops)
 	return int(C.Mix_PlayMusic(_music, _loops)) == 0
 }
 
 func (music *Music) FadeIn(loops, ms int) bool {
-	_music := (*C.Mix_Music) (unsafe.Pointer(music))
-	_loops := (C.int) (loops)
-	_ms := (C.int) (ms)
+	_music := (*C.Mix_Music)(unsafe.Pointer(music))
+	_loops := (C.int)(loops)
+	_ms := (C.int)(ms)
 	return int(C.Mix_FadeInMusic(_music, _loops, _ms)) == 0
 }
 
 func (music *Music) FadeInPos(loops, ms int, position float64) bool {
-	_music := (*C.Mix_Music) (unsafe.Pointer(music))
-	_loops := (C.int) (loops)
-	_ms := (C.int) (ms)
-	_position := (C.double) (position)
+	_music := (*C.Mix_Music)(unsafe.Pointer(music))
+	_loops := (C.int)(loops)
+	_ms := (C.int)(ms)
+	_position := (C.double)(position)
 	return int(C.Mix_FadeInMusicPos(_music, _loops, _ms, _position)) == 0
 }
 
-func (chunk *Chunk) FadeIn(channel, loops, ms, ticks int ) bool {
-	_channel := (C.int) (channel)
-	_chunk := (*C.Mix_Chunk) (unsafe.Pointer(chunk))
-	_loops := (C.int) (loops)
-	_ms := (C.int) (ms)
+func (chunk *Chunk) FadeIn(channel, loops, ms, ticks int) bool {
+	_channel := (C.int)(channel)
+	_chunk := (*C.Mix_Chunk)(unsafe.Pointer(chunk))
+	_loops := (C.int)(loops)
+	_ms := (C.int)(ms)
 	return int(C.Mix_FadeInChannelTimed(_channel, _chunk, _loops, _ms, -1)) == 0
 }
 
 func (chunk *Chunk) FadeInTimed(channel, loops, ms, ticks int) bool {
-	_channel := (C.int) (channel)
-	_chunk := (*C.Mix_Chunk) (unsafe.Pointer(chunk))
-	_loops := (C.int) (loops)
-	_ms := (C.int) (ms)
-	_ticks := (C.int) (ticks)
+	_channel := (C.int)(channel)
+	_chunk := (*C.Mix_Chunk)(unsafe.Pointer(chunk))
+	_loops := (C.int)(loops)
+	_ms := (C.int)(ms)
+	_ticks := (C.int)(ticks)
 	return int(C.Mix_FadeInChannelTimed(_channel, _chunk, _loops, _ms,
-			_ticks)) == 0
+		_ticks)) == 0
 }
 
 func SetVolume(channel, volume int) int {
-	_channel := (C.int) (channel)
-	_volume := (C.int) (volume)
-	return (int) (C.Mix_Volume(_channel, _volume))
+	_channel := (C.int)(channel)
+	_volume := (C.int)(volume)
+	return (int)(C.Mix_Volume(_channel, _volume))
 }
 
 func (chunk *Chunk) SetVolume(volume int) int {
-	_chunk := (*C.Mix_Chunk) (unsafe.Pointer(chunk))
-	_volume := (C.int) (volume)
-	return (int) (C.Mix_VolumeChunk(_chunk, _volume))
+	_chunk := (*C.Mix_Chunk)(unsafe.Pointer(chunk))
+	_volume := (C.int)(volume)
+	return (int)(C.Mix_VolumeChunk(_chunk, _volume))
 }
 
 func SetMusicVolume(volume int) int {
-	_volume := (C.int) (volume)
-	return (int) (C.Mix_VolumeMusic(_volume))
+	_volume := (C.int)(volume)
+	return (int)(C.Mix_VolumeMusic(_volume))
 }
 
 func HaltChannel(channel int) bool {
-	_channel := (C.int) (channel)
+	_channel := (C.int)(channel)
 	return int(C.Mix_HaltChannel(_channel)) == 0
 }
 
 func HaltGroup(tag int) bool {
-	_tag := (C.int) (tag)
+	_tag := (C.int)(tag)
 	return int(C.Mix_HaltGroup(_tag)) == 0
 }
 
@@ -275,49 +278,49 @@ func HaltMusic() bool {
 }
 
 func ExpireChannel(channel, ticks int) bool {
-	_channel := (C.int) (channel)
-	_ticks := (C.int) (ticks)
+	_channel := (C.int)(channel)
+	_ticks := (C.int)(ticks)
 	return int(C.Mix_ExpireChannel(_channel, _ticks)) == 0
 }
 
 func FadeOutChannel(which, ms int) bool {
-	_which := (C.int) (which)
-	_ms := (C.int) (ms)
+	_which := (C.int)(which)
+	_ms := (C.int)(ms)
 	return int(C.Mix_FadeOutChannel(_which, _ms)) == 0
 }
 
 func FadeOutGroup(tag, ms int) bool {
-	_tag := (C.int) (tag)
-	_ms := (C.int) (ms)
+	_tag := (C.int)(tag)
+	_ms := (C.int)(ms)
 	return int(C.Mix_FadeOutGroup(_tag, _ms)) == 0
 }
 
 func FadeOutMusic(ms int) bool {
-	_ms := (C.int) (ms)
+	_ms := (C.int)(ms)
 	return int(C.Mix_FadeOutMusic(_ms)) == 0
 }
 
 func FadingMusic() Fading {
-	return (Fading) (C.Mix_FadingMusic())
+	return (Fading)(C.Mix_FadingMusic())
 }
 
 func FadingChannel(which int) Fading {
-	_which := (C.int) (which)
-	return (Fading) (C.Mix_FadingChannel(_which))
+	_which := (C.int)(which)
+	return (Fading)(C.Mix_FadingChannel(_which))
 }
 
 func Pause(channel int) {
-	_channel := (C.int) (channel)
+	_channel := (C.int)(channel)
 	C.Mix_Pause(_channel)
 }
 
 func Resume(channel int) {
-	_channel := (C.int) (channel)
+	_channel := (C.int)(channel)
 	C.Mix_Resume(_channel)
 }
 
 func Paused(channel int) bool {
-	_channel := (C.int) (channel)
+	_channel := (C.int)(channel)
 	return int(C.Mix_Paused(_channel)) > 0
 }
 
@@ -338,12 +341,12 @@ func PausedMusic() bool {
 }
 
 func SetMusicPosition(position int64) bool {
-	_position := (C.double) (position)
+	_position := (C.double)(position)
 	return int(C.Mix_SetMusicPosition(_position)) == 0
 }
 
 func Playing(channel int) bool {
-	_channel := (C.int) (channel)
+	_channel := (C.int)(channel)
 	return int(C.Mix_Playing(_channel)) > 0
 }
 
@@ -352,31 +355,33 @@ func MusicPlaying() bool {
 }
 
 func SetMusicCMD(command string) bool {
-	_command := (C.CString) (command)
+	_command := C.CString(command)
+	defer C.free(unsafe.Pointer(_command))
 	return int(C.Mix_SetMusicCMD(_command)) == 0
 }
 
 func SetSynchroValue(value int) bool {
-	_value := (C.int) (value)
+	_value := (C.int)(value)
 	return int(C.Mix_SetSynchroValue(_value)) == 0
 }
 
 func GetSynchroValue() int {
-	return (int) (C.Mix_GetSynchroValue())
+	return (int)(C.Mix_GetSynchroValue())
 }
 
 func SetSoundFonts(paths string) bool {
-	_paths := (C.CString) (paths)
+	_paths := C.CString(paths)
+	defer C.free(unsafe.Pointer(_paths))
 	return int(C.Mix_SetSoundFonts(_paths)) == 0
 }
 
 func GetSoundFonts() string {
-	return (string) (C.GoString(C.Mix_GetSoundFonts()))
+	return (string)(C.GoString(C.Mix_GetSoundFonts()))
 }
 
 func GetChunk(channel int) *Chunk {
-	_channel := (C.int) (channel)
-	return (*Chunk) (unsafe.Pointer(C.Mix_GetChunk(_channel)))
+	_channel := (C.int)(channel)
+	return (*Chunk)(unsafe.Pointer(C.Mix_GetChunk(_channel)))
 }
 
 func CloseAudio() {

--- a/sdl_ttf/sdl_ttf.go
+++ b/sdl_ttf/sdl_ttf.go
@@ -12,25 +12,24 @@ import "errors"
 
 //Font Hinting Types
 const (
-	HINTING_NORMAL	= int(C.TTF_HINTING_NORMAL)
-	HINTING_LIGHT	= int(C.TTF_HINTING_LIGHT)
-	HINTING_MONO	= int(C.TTF_HINTING_MONO)
-	HINTING_NONE	= int(C.TTF_HINTING_NONE)
+	HINTING_NORMAL = int(C.TTF_HINTING_NORMAL)
+	HINTING_LIGHT  = int(C.TTF_HINTING_LIGHT)
+	HINTING_MONO   = int(C.TTF_HINTING_MONO)
+	HINTING_NONE   = int(C.TTF_HINTING_NONE)
 )
 
 //Font Style Types
 const (
-	STYLE_NORMAL		= 0
-	STYLE_BOLD			= 0x01
-	STYLE_ITALIC		= 0x02
-	STYLE_UNDERLINE		= 0x04
+	STYLE_NORMAL        = 0
+	STYLE_BOLD          = 0x01
+	STYLE_ITALIC        = 0x02
+	STYLE_UNDERLINE     = 0x04
 	STYLE_STRIKETHROUGH = 0x08
 )
 
 type Font struct {
 	f *C.TTF_Font
 }
-
 
 func Init() int {
 	return int(C.TTF_Init())
@@ -53,62 +52,66 @@ func GetError() error {
 }
 
 func SetError(err string) {
-	_err := (C.CString) (err)
+	_err := C.CString(err)
+	defer C.free(unsafe.Pointer(_err))
 	C.Do_TTF_SetError(_err)
-	C.free(unsafe.Pointer(_err))
 }
 
 func ByteSwappedUnicode(swap bool) {
 	val := 0
-	if swap {val = 1}
+	if swap {
+		val = 1
+	}
 	C.TTF_ByteSwappedUNICODE(C.int(val))
 }
 
-func OpenFont(file string, size int) (*Font,error) {
-	_file := (C.CString) (file)
-	_size := (C.int) (size)
-	f := (*C.TTF_Font) (C.TTF_OpenFont(_file, _size))
-	C.free(unsafe.Pointer(_file))
+func OpenFont(file string, size int) (*Font, error) {
+	_file := C.CString(file)
+	defer C.free(unsafe.Pointer(_file))
+	_size := (C.int)(size)
+	f := (*C.TTF_Font)(C.TTF_OpenFont(_file, _size))
+
 	if f == nil {
-		return nil,GetError()
+		return nil, GetError()
 	}
-	return &Font{f},nil
+	return &Font{f}, nil
 }
 
-func OpenFontIndex(file string, size int, index int) (*Font,error) {
-	_file := (C.CString) (file)
-	_size := (C.int) (size)
-	_index := (C.long) (index)
-	f := (*C.TTF_Font) (C.TTF_OpenFontIndex(_file, _size, _index))
-	C.free(unsafe.Pointer(_file))
+func OpenFontIndex(file string, size int, index int) (*Font, error) {
+	_file := C.CString(file)
+	defer C.free(unsafe.Pointer(_file))
+	_size := (C.int)(size)
+	_index := (C.long)(index)
+	f := (*C.TTF_Font)(C.TTF_OpenFontIndex(_file, _size, _index))
+
 	if f == nil {
-		return nil,GetError()
+		return nil, GetError()
 	}
-	return &Font{f},nil
+	return &Font{f}, nil
 }
 
 func (f *Font) RenderText_Solid(text string, color sdl.Color) *sdl.Surface {
 	_text := C.CString(text)
+	defer C.free(unsafe.Pointer(_text))
 	_c := C.SDL_Color{C.Uint8(color.R), C.Uint8(color.G), C.Uint8(color.B), C.Uint8(color.A)}
-	surface := (*sdl.Surface) (unsafe.Pointer(C.TTF_RenderText_Solid(f.f, _text, _c)))
-	C.free(unsafe.Pointer(_text))
+	surface := (*sdl.Surface)(unsafe.Pointer(C.TTF_RenderText_Solid(f.f, _text, _c)))
 	return surface
 }
 
 func (f *Font) RenderText_Shaded(text string, fg, bg sdl.Color) *sdl.Surface {
 	_text := C.CString(text)
+	defer C.free(unsafe.Pointer(_text))
 	_fg := C.SDL_Color{C.Uint8(fg.R), C.Uint8(fg.G), C.Uint8(fg.B), C.Uint8(fg.A)}
 	_bg := C.SDL_Color{C.Uint8(bg.R), C.Uint8(bg.G), C.Uint8(bg.B), C.Uint8(bg.A)}
-	surface := (*sdl.Surface) (unsafe.Pointer(C.TTF_RenderText_Shaded(f.f, _text, _fg, _bg)))
-	C.free(unsafe.Pointer(_text))
+	surface := (*sdl.Surface)(unsafe.Pointer(C.TTF_RenderText_Shaded(f.f, _text, _fg, _bg)))
 	return surface
 }
 
 func (f *Font) RenderText_Blended(text string, color sdl.Color) *sdl.Surface {
 	_text := C.CString(text)
+	defer C.free(unsafe.Pointer(_text))
 	_c := C.SDL_Color{C.Uint8(color.R), C.Uint8(color.G), C.Uint8(color.B), C.Uint8(color.A)}
-	surface := (*sdl.Surface) (unsafe.Pointer(C.TTF_RenderText_Blended(f.f, _text, _c)))
-	C.free(unsafe.Pointer(_text))
+	surface := (*sdl.Surface)(unsafe.Pointer(C.TTF_RenderText_Blended(f.f, _text, _c)))
 	return surface
 }
 
@@ -117,11 +120,11 @@ func (f *Font) Close() {
 	f.f = nil
 }
 
-func (f *Font) Height() int { return int(C.TTF_FontHeight(f.f)) }
-func (f *Font) Ascent() int { return int(C.TTF_FontAscent(f.f)) }
-func (f *Font) Descent() int { return int(C.TTF_FontDescent(f.f)) }
+func (f *Font) Height() int   { return int(C.TTF_FontHeight(f.f)) }
+func (f *Font) Ascent() int   { return int(C.TTF_FontAscent(f.f)) }
+func (f *Font) Descent() int  { return int(C.TTF_FontDescent(f.f)) }
 func (f *Font) LineSkip() int { return int(C.TTF_FontLineSkip(f.f)) }
-func (f *Font) Faces() int { return int(C.TTF_FontFaces(f.f)) }
+func (f *Font) Faces() int    { return int(C.TTF_FontFaces(f.f)) }
 
 func (f *Font) GetStyle() int {
 	return int(C.TTF_GetFontStyle(f.f))
@@ -145,7 +148,9 @@ func (f *Font) GetKerning() bool {
 
 func (f *Font) SetKerning(allowed bool) {
 	val := 0
-	if allowed {val = 1}
+	if allowed {
+		val = 1
+	}
 	C.TTF_SetFontKerning(f.f, C.int(val))
 }
 


### PR DESCRIPTION
I know it is a lot. Most of it go fmt, because in GoSublime it is hard not to do this. But I lookt for all instances of C.CString and added a defer C.free. There was a bug in GetError that is fixed now. Some window functions are methods now. Some Get Methods actually use multiple return values instead of pointers.
