### PR TITLE
Do not use SDL_free() on C.CString() items

### DIFF
--- a/sdl/sdl_clipboard.go
+++ b/sdl/sdl_clipboard.go
@@ -7,7 +7,7 @@ import "unsafe"
 
 func SetClipboardText(text string) int {
 	_text := C.CString(text)
-	defer C.SDL_free(unsafe.Pointer(_text))
+	defer C.free(unsafe.Pointer(_text))
 	return (int)(C.SDL_SetClipboardText(_text))
 }
 

--- a/sdl/sdl_gamecontroller.go
+++ b/sdl/sdl_gamecontroller.go
@@ -50,7 +50,7 @@ type GameControllerButtonBind C.SDL_GameControllerButtonBind
 
 func GameControllerAddMapping(mappingString string) int {
 	_mappingString := C.CString(mappingString)
-	defer C.SDL_free(unsafe.Pointer(_mappingString))
+	defer C.free(unsafe.Pointer(_mappingString))
 	return (int)(C.SDL_GameControllerAddMapping(_mappingString))
 }
 
@@ -100,7 +100,7 @@ func GameControllerUpdate() {
 
 func GameControllerGetAxisFromString(pchString string) GameControllerAxis {
 	_pchString := C.CString(pchString)
-	defer C.SDL_free(unsafe.Pointer(_pchString))
+	defer C.free(unsafe.Pointer(_pchString))
 	return (GameControllerAxis)(C.SDL_GameControllerGetAxisFromString(_pchString))
 }
 
@@ -123,7 +123,7 @@ func (gamecontroller *GameController) GetAxis(axis GameControllerAxis) int16 {
 
 func GameControllerGetButtonFromString(pchString string) GameControllerButton {
 	_pchString := C.CString(pchString)
-	defer C.SDL_free(unsafe.Pointer(_pchString))
+	defer C.free(unsafe.Pointer(_pchString))
 	return (GameControllerButton)(C.SDL_GameControllerGetButtonFromString(_pchString))
 }
 

--- a/sdl/sdl_joystick.go
+++ b/sdl/sdl_joystick.go
@@ -52,14 +52,14 @@ func (joystick *Joystick) GetGUID() JoystickGUID {
 func JoystickGetGUIDString(guid JoystickGUID, pszGUID string, cbGUID int) {
 	_guid := (C.SDL_JoystickGUID)(guid)
 	_pszGUID := C.CString(pszGUID)
-	defer C.SDL_free(unsafe.Pointer(_pszGUID))
+	defer C.free(unsafe.Pointer(_pszGUID))
 	_cbGUID := (C.int)(cbGUID)
 	C.SDL_JoystickGetGUIDString(_guid, _pszGUID, _cbGUID)
 }
 
 func JoystickGetGUIDFromString(pchGUID string) JoystickGUID {
 	_pchGUID := C.CString(pchGUID)
-	defer C.SDL_free(unsafe.Pointer(_pchGUID))
+	defer C.free(unsafe.Pointer(_pchGUID))
 	return (JoystickGUID)(C.SDL_JoystickGetGUIDFromString(_pchGUID))
 }
 

--- a/sdl/sdl_loadso.go
+++ b/sdl/sdl_loadso.go
@@ -6,13 +6,13 @@ import "unsafe"
 
 func LoadObject(sofile string) unsafe.Pointer {
 	_sofile := C.CString(sofile)
-	defer C.SDL_free(unsafe.Pointer(_sofile))
+	defer C.free(unsafe.Pointer(_sofile))
 	return (unsafe.Pointer)(C.SDL_LoadObject(_sofile))
 }
 
 func LoadFunction(handle unsafe.Pointer, name string) unsafe.Pointer {
 	_name := C.CString(name)
-	defer C.SDL_free(unsafe.Pointer(_name))
+	defer C.free(unsafe.Pointer(_name))
 	return (unsafe.Pointer)(C.SDL_LoadFunction(handle, _name))
 }
 


### PR DESCRIPTION
Do not use `SDL_free()` on `C.CString()` items that were allocated by go's own memory management routines, since `SDL_malloc()` and `SDL_free()` might use an own memory manager (dlmalloc), if `malloc()` is not available on the target platform, the SDL2 library was built for.
