### PR TITLE
Add some handy build commands

### DIFF
--- a/BSDmakefile
+++ b/BSDmakefile
@@ -1,0 +1,42 @@
+# Directories
+SRCDIR=		${.CURDIR}
+ALLDIRS!=	find ${SRCDIR} -type d -not -path "./.git*"
+# Packages
+ROOTPKG=	${SRCDIR:S/${GOPATH}\/src\///}
+PACKAGES=	sdl sdl_image sdl_mixer sdl_ttf
+# Some cleanups
+CLEANUP=	*.cache *.core *~ *.orig
+
+GO?=		go
+
+all: clean packages
+
+clean:
+	@echo "Cleaning up..."
+	@for dir in ${ALLDIRS}; do \
+		cd $$dir && rm -f ${CLEANUP} && cd ${SRCDIR}; \
+	done
+
+packages:
+	@for pkg in ${PACKAGES}; do \
+		echo "Building package ${ROOTPKG}/$$pkg..."; \
+		${GO} build ${ROOTPKG}/$$pkg; \
+	done
+
+test:
+	@for pkg in ${PACKAGES}; do \
+		echo "Testing ${ROOTPKG}/$$pkg..."; \
+		${GO} test -v ${ROOTPKG}/$$pkg; \
+	done
+
+coverage:
+	@for pkg in ${PACKAGES}; do \
+		echo "Coverage for ${ROOTPKG}/$$pkg..."; \
+		${GO} test -cover ${ROOTPKG}/$$pkg; \
+	done
+
+bench:
+	@for pkg in ${PACKAGES}; do \
+		echo "Benchmarking ${ROOTPKG}/$$pkg..."; \
+		${GO} test -bench=. -cpu 1,2,3,4 ${ROOTPKG}/$$pkg; \
+	done

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,42 @@
+# Directories
+SRCDIR=		${CURDIR}
+ALLDIRS!=	find ${SRCDIR} -type d -not -path "./.git*"
+# Packages
+ROOTPKG=	$(subst ${GOPATH}/src/,,${SRCDIR})
+PACKAGES=	sdl sdl_image sdl_mixer sdl_ttf
+# Some cleanups
+CLEANUP=	*.cache *.core *~ *.orig
+
+GO?=		go
+
+all: clean packages
+
+clean:
+	@echo "Cleaning up..."
+	@for dir in ${ALLDIRS}; do \
+		cd $$dir && rm -f ${CLEANUP} && cd ${SRCDIR}; \
+	done
+
+packages:
+	@for pkg in ${PACKAGES}; do \
+		echo "Building package ${ROOTPKG}/$$pkg..."; \
+		${GO} build ${ROOTPKG}/$$pkg; \
+	done
+
+test:
+	@for pkg in ${PACKAGES}; do \
+		echo "Testing ${ROOTPKG}/$$pkg..."; \
+		${GO} test -v ${ROOTPKG}/$$pkg; \
+	done
+
+coverage:
+	@for pkg in ${PACKAGES}; do \
+		echo "Coverage for ${ROOTPKG}/$$pkg..."; \
+		${GO} test -cover ${ROOTPKG}/$$pkg; \
+	done
+
+bench:
+	@for pkg in ${PACKAGES}; do \
+		echo "Benchmarking ${ROOTPKG}/$$pkg..."; \
+		${GO} test -bench=. -cpu 1,2,3,4 ${ROOTPKG}/$$pkg; \
+	done

--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,46 @@
+@ECHO OFF
+SETLOCAL
+
+REM Directories
+SET SRCDIR=%CD%
+
+REM @SET ALLDIRS!=	find ${SRCDIR} -type d -not -path "./.hg*"
+
+REM Packages
+SET ROOTPKG=github.com/jackyb/go-sdl2
+SET PACKAGES=sdl sdl_image sdl_mixer sdl_ttf
+
+SET GO=go
+
+@IF "%~1" == "" GOTO :all
+@GOTO :%~1
+
+:all
+CALL :packages
+GOTO :eof
+
+:test
+CALL :packages
+FOR %%p IN (%PACKAGES%) DO (
+	ECHO Testing %ROOTPKG%/%%p...
+	%GO% test -v %ROOTPKG%/%%p
+)
+GOTO :eof
+
+:bench
+CALL :packages
+FOR %%p IN (%PACKAGES%) DO (
+	ECHO Benchmarking %ROOTPKG%/%%p...
+	%GO% test -bench=. -cpu 1,2,3,4 %ROOTPKG%/%%p
+)
+GOTO :eof
+
+:packages
+FOR %%p IN (%PACKAGES%) DO (
+	ECHO Building package %ROOTPKG%/%%p...
+	%GO% build %ROOTPKG%/%%p
+)
+GOTO :eof
+
+ENDLOCAL
+ECHO ON


### PR DESCRIPTION
Add some handy build commands from go-gogadget for GNU and BSD make as well as Win32 platforms:
- `make packages` builds all packages
- `make test` executes all Go tests for all packages
- `make coverage` creates the code coverage for the Go tests
- `make bench` executes any test benchmarks (TBD) for the packages
- `make clean` removes temp files and core dumps
- `make` executes `make clean` and `make packages`
