### PR TITLE
Add darwin cgo build commands for Mac OSX targets.

### DIFF
--- a/sdl/sdl.go
+++ b/sdl/sdl.go
@@ -1,6 +1,7 @@
 package sdl
 
 // #cgo windows LDFLAGS: -lSDL2
+// #cgo darwin LDFLAGS: -lSDL2
 // #cgo linux freebsd pkg-config: sdl2
 // #include <SDL2/SDL.h>
 import "C"

--- a/sdl_image/sdl_image.go
+++ b/sdl_image/sdl_image.go
@@ -2,6 +2,7 @@ package img
 
 //#cgo linux freebsd pkg-config: sdl2
 //#cgo linux freebsd LDFLAGS: -lSDL2_image
+//#cgo darwin LDFLAGS: -lSDL2 -lSDL2_image
 //#cgo windows LDFLAGS: -lSDL2 -lSDL2_image
 //#include <stdlib.h>
 //#include <SDL2/SDL_image.h>

--- a/sdl_mixer/sdl_mixer.go
+++ b/sdl_mixer/sdl_mixer.go
@@ -1,6 +1,7 @@
 package mix
 
 //#cgo windows LDFLAGS: -lSDL2 -lSDL2_mixer
+//#cgo darwin LDFLAGS: -lSDL2 -lSDL2_mixer
 //#cgo linux freebsd pkg-config: sdl2
 //#cgo linux freebsd LDFLAGS: -lSDL2_mixer
 //#include <stdlib.h>

--- a/sdl_ttf/sdl_ttf.go
+++ b/sdl_ttf/sdl_ttf.go
@@ -1,6 +1,7 @@
 package ttf
 
 //#cgo windows LDFLAGS: -lSDL2 -lSDL2_ttf
+//#cgo darwin LDFLAGS: -lSDL2 -lSDL2_ttf
 //#cgo linux freebsd pkg-config: sdl2
 //#cgo linux freebsd LDFLAGS: -lSDL2_ttf
 //#include <stdlib.h>


### PR DESCRIPTION
Add cgo SDL2 build commands for darwin targets, mainly Mac OSX.
