### PR TITLE
Fixed CFLAG and LDFLAG refs for OSX Macports install of SDL2_ttf

### DIFF
--- a/sdl_ttf/sdl_ttf.go
+++ b/sdl_ttf/sdl_ttf.go
@@ -1,15 +1,12 @@
 package ttf
 
+//#cgo darwin CFLAGS: -I/opt/local/include/
 //#cgo windows LDFLAGS: -lSDL2 -lSDL2_ttf
-//#cgo darwin LDFLAGS: -framework SDL2 -framework SDL2_ttf
+//#cgo darwin LDFLAGS: -L/opt/local/lib/ -lSDL2 -lSDL2_ttf
 //#cgo linux freebsd pkg-config: sdl2
 //#cgo linux freebsd LDFLAGS: -lSDL2_ttf
 //#include <stdlib.h>
-//#if defined(__APPLE__)
-//#include <SDL2_ttf/SDL_ttf.h>
-//#else
 //#include <SDL2/SDL_ttf.h>
-//#endif
 //void Do_TTF_SetError(const char *str) {
 //    TTF_SetError(str);
 //}


### PR DESCRIPTION
Same as PR #57 but for SDL2_ttf. It appears that each sub package may suffer from the same issues so this is the first of the PRs to fix this. I'm learning go-sdl2 so as I learn to use each sub pkg I'll take some time to make sure they compile correctly for others.
