### PR TITLE
Mac OS X don't need any particular build flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ On __Fedora 20 and above__, type:
 On __Arch Linux__, type:  
 `pacman -S sdl2{,_mixer,_image,_ttf}`
 
-On __Mac OS X__, install SDL2 via Macports like so:  
-`sudo port install libsdl2 libsdl2_image libsdl2_ttf`
+On __Mac OS X__, install SDL2 via [Homebrew](http://brew.sh) like so:
+`brew install sdl2{,_image,_ttf,_mixer}`
 
 
 Installation

--- a/sdl/sdl.go
+++ b/sdl/sdl.go
@@ -1,9 +1,7 @@
 package sdl
 
-// #cgo darwin CFLAGS: -I/opt/local/include/
 // #cgo windows LDFLAGS: -lSDL2
-// #cgo darwin LDFLAGS: -L/opt/local/lib/ -lSDL2
-// #cgo linux freebsd pkg-config: sdl2
+// #cgo linux freebsd darwin pkg-config: sdl2
 // #include <SDL2/SDL.h>
 import "C"
 

--- a/sdl_image/sdl_image.go
+++ b/sdl_image/sdl_image.go
@@ -1,15 +1,10 @@
 package img
 
-//#cgo linux freebsd pkg-config: sdl2
-//#cgo linux freebsd LDFLAGS: -lSDL2_image
-//#cgo darwin LDFLAGS: -framework SDL2 -framework SDL2_image
+//#cgo linux freebsd darwin pkg-config: sdl2
+//#cgo linux freebsd darwin LDFLAGS: -lSDL2_image
 //#cgo windows LDFLAGS: -lSDL2 -lSDL2_image
 //#include <stdlib.h>
-//#if defined(__APPLE__)
-//#include <SDL2_image/SDL_image.h>
-//#else
 //#include <SDL2/SDL_image.h>
-//#endif
 import "C"
 import "unsafe"
 import "errors"

--- a/sdl_mixer/sdl_mixer.go
+++ b/sdl_mixer/sdl_mixer.go
@@ -1,15 +1,10 @@
 package mix
 
 //#cgo windows LDFLAGS: -lSDL2 -lSDL2_mixer
-//#cgo darwin LDFLAGS: -framework SDL2 -framework SDL2_mixer
-//#cgo linux freebsd pkg-config: sdl2
-//#cgo linux freebsd LDFLAGS: -lSDL2_mixer
+//#cgo linux freebsd darwin pkg-config: sdl2
+//#cgo linux freebsd darwin LDFLAGS: -lSDL2_mixer
 //#include <stdlib.h>
-//#if defined(__APPLE__)
-//#include <SDL2_mixer/SDL_mixer.h>
-//#else
 //#include <SDL2/SDL_mixer.h>
-//#endif
 //
 //extern void callPostMixFunction(void *udata, Uint8* stream, int length);
 //extern void callHookMusic(void *udata, Uint8* stream, int length);

--- a/sdl_ttf/sdl_ttf.go
+++ b/sdl_ttf/sdl_ttf.go
@@ -1,10 +1,8 @@
 package ttf
 
-//#cgo darwin CFLAGS: -I/opt/local/include/
 //#cgo windows LDFLAGS: -lSDL2 -lSDL2_ttf
-//#cgo darwin LDFLAGS: -L/opt/local/lib/ -lSDL2 -lSDL2_ttf
-//#cgo linux freebsd pkg-config: sdl2
-//#cgo linux freebsd LDFLAGS: -lSDL2_ttf
+//#cgo linux freebsd darwin pkg-config: sdl2
+//#cgo linux freebsd darwin LDFLAGS: -lSDL2_ttf
 //#include <stdlib.h>
 //#include <SDL2/SDL_ttf.h>
 //void Do_TTF_SetError(const char *str) {


### PR DESCRIPTION
Everything builds fine with the default unix flags when _SDL2_ is installed via _Homebrew_.
