### PR TITLE
Fix sample in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,21 +45,26 @@ compilation time because Go doesn't keep the built binaries unless you install t
 Example
 =======
 	package main
-
+	
 	import "github.com/veandco/go-sdl2/sdl"
-
+	
 	func main() {
-		window := sdl.CreateWindow("test", sdl.WINDOWPOS_UNDEFINED, sdl.WINDOWPOS_UNDEFINED,
-				800, 600, sdl.WINDOW_SHOWN)
+		window, err := sdl.CreateWindow("test", sdl.WINDOWPOS_UNDEFINED, sdl.WINDOWPOS_UNDEFINED,
+			800, 600, sdl.WINDOW_SHOWN)
+		if err != nil {
+			panic(err)
+		}
+	
 		surface := window.GetSurface()
-
-		rect := sdl.Rect { 0, 0, 200, 200 }
+	
+		rect := sdl.Rect{0, 0, 200, 200}
 		surface.FillRect(&rect, 0xffff0000)
 		window.UpdateSurface()
-
+	
 		sdl.Delay(1000)
 		window.Destroy()
 	}
+
 
 
 For more complete examples, see inside the _examples_ folder.


### PR DESCRIPTION
The sample did take into account, that sdl.CreateWindow() returns multiple values. This is an updated (and go fmt-ted) version.
