### PR TITLE
Update example render code for new API

### DIFF
--- a/examples/render.go
+++ b/examples/render.go
@@ -31,6 +31,8 @@ func main() {
 		os.Exit(2)
 	}
 
+	renderer.Clear()
+
 	renderer.SetDrawColor(255, 255, 255, 255)
 	renderer.DrawPoint(150, 300)
 


### PR DESCRIPTION
The renderer example doesn't work out of the box because the Create\* statements hand back errors along with objects now. Updated those, and added a call the clear on the renderer to prevent junk being displayed to screen.
