### PR TITLE
Fix misuses of C.SDL_free

### DIFF
--- a/sdl/audio.go
+++ b/sdl/audio.go
@@ -140,7 +140,7 @@ func GetAudioDriver(index int) string {
 // AudioInit (https://wiki.libsdl.org/SDL_AudioInit)
 func AudioInit(driverName string) int {
 	_driverName := C.CString(driverName)
-	defer C.SDL_free(unsafe.Pointer(_driverName))
+	defer C.free(unsafe.Pointer(_driverName))
 	return int(C.SDL_AudioInit(_driverName))
 }
 
@@ -172,7 +172,7 @@ func GetAudioDeviceName(index, isCapture int) string {
 // OpenAudioDevice (https://wiki.libsdl.org/SDL_OpenAudioDevice)
 func OpenAudioDevice(device string, isCapture int, desired, obtained *AudioSpec, allowedChanges int) int {
 	_device := C.CString(device)
-	defer C.SDL_free(unsafe.Pointer(_device))
+	defer C.free(unsafe.Pointer(_device))
 	return int(C.SDL_OpenAudioDevice(_device, C.int(isCapture), desired.cptr(), obtained.cptr(), C.int(allowedChanges)))
 }
 
@@ -207,8 +207,8 @@ func LoadWAV_RW(src *RWops, freeSrc int, spec *AudioSpec, audioBuf **uint8, audi
 func LoadWAV(file string, spec *AudioSpec, audioBuf **uint8, audioLen *uint32) *AudioSpec {
 	_file := C.CString(file)
 	_rb := C.CString("rb")
-	defer C.SDL_free(unsafe.Pointer(_file))
-	defer C.SDL_free(unsafe.Pointer(_rb))
+	defer C.free(unsafe.Pointer(_file))
+	defer C.free(unsafe.Pointer(_rb))
 	_audioBuf := (**C.Uint8)(unsafe.Pointer(audioBuf))
 	_audioLen := (*C.Uint32)(unsafe.Pointer(audioLen))
 	return (*AudioSpec)(unsafe.Pointer(C.SDL_LoadWAV_RW(C.SDL_RWFromFile(_file, _rb), 1, spec.cptr(), _audioBuf, _audioLen)))

--- a/sdl/clipboard.go
+++ b/sdl/clipboard.go
@@ -7,13 +7,16 @@ import "unsafe"
 // SetClipboardText (https://wiki.libsdl.org/SDL_SetClipboardText)
 func SetClipboardText(text string) int {
 	_text := C.CString(text)
-	defer C.SDL_free(unsafe.Pointer(_text))
+	defer C.free(unsafe.Pointer(_text))
 	return int(C.SDL_SetClipboardText(_text))
 }
 
 // GetClipboardText (https://wiki.libsdl.org/SDL_GetClipboardText)
 func GetClipboardText() string {
-	return C.GoString(C.SDL_GetClipboardText())
+	text := C.SDL_GetClipboardText()
+	defer C.SDL_free(unsafe.Pointer(text))
+	_text := C.GoString(text)
+	return _text
 }
 
 // HasClipboardText (https://wiki.libsdl.org/SDL_HasClipboardText)

--- a/sdl/filesystem.go
+++ b/sdl/filesystem.go
@@ -35,8 +35,8 @@ func GetBasePath() string {
 func GetPrefPath(org, app string) string {
 	_org := C.CString(org)
 	_app := C.CString(app)
-	defer C.SDL_free(unsafe.Pointer(_org))
-	defer C.SDL_free(unsafe.Pointer(_app))
+	defer C.free(unsafe.Pointer(_org))
+	defer C.free(unsafe.Pointer(_app))
 	_val := C._SDL_GetPrefPath(_org, _app)
 	defer C.SDL_free(unsafe.Pointer(_val))
 	return C.GoString(_val)

--- a/sdl/gamecontroller.go
+++ b/sdl/gamecontroller.go
@@ -64,7 +64,7 @@ func (btn GameControllerButton) c() C.SDL_GameControllerButton {
 // GameControllerAddMapping (https://wiki.libsdl.org/SDL_GameControllerAddMapping)
 func GameControllerAddMapping(mappingString string) int {
 	_mappingString := C.CString(mappingString)
-	defer C.SDL_free(unsafe.Pointer(_mappingString))
+	defer C.free(unsafe.Pointer(_mappingString))
 	return int(C.SDL_GameControllerAddMapping(_mappingString))
 }
 
@@ -121,7 +121,7 @@ func GameControllerUpdate() {
 // GameControllerGetAxisFromString (https://wiki.libsdl.org/SDL_GameControllerGetAxisFromString)
 func GameControllerGetAxisFromString(pchString string) GameControllerAxis {
 	_pchString := C.CString(pchString)
-	defer C.SDL_free(unsafe.Pointer(_pchString))
+	defer C.free(unsafe.Pointer(_pchString))
 	return GameControllerAxis(C.SDL_GameControllerGetAxisFromString(_pchString))
 }
 
@@ -143,7 +143,7 @@ func (ctrl *GameController) GetAxis(axis GameControllerAxis) int16 {
 // GameControllerGetButtonFromString (https://wiki.libsdl.org/SDL_GameControllerGetButtonFromString)
 func GameControllerGetButtonFromString(pchString string) GameControllerButton {
 	_pchString := C.CString(pchString)
-	defer C.SDL_free(unsafe.Pointer(_pchString))
+	defer C.free(unsafe.Pointer(_pchString))
 	return GameControllerButton(C.SDL_GameControllerGetButtonFromString(_pchString))
 }
 

--- a/sdl/hints.go
+++ b/sdl/hints.go
@@ -77,8 +77,8 @@ func (hp HintPriority) c() C.SDL_HintPriority {
 func SetHintWithPriority(name, value string, hp HintPriority) bool {
 	_name := C.CString(name)
 	_value := C.CString(value)
-	defer C.SDL_free(unsafe.Pointer(_name))
-	defer C.SDL_free(unsafe.Pointer(_value))
+	defer C.free(unsafe.Pointer(_name))
+	defer C.free(unsafe.Pointer(_value))
 	return C.SDL_SetHintWithPriority(_name, _value, hp.c()) > 0
 }
 
@@ -86,15 +86,15 @@ func SetHintWithPriority(name, value string, hp HintPriority) bool {
 func SetHint(name, value string) bool {
 	_name := C.CString(name)
 	_value := C.CString(value)
-	defer C.SDL_free(unsafe.Pointer(_name))
-	defer C.SDL_free(unsafe.Pointer(_value))
+	defer C.free(unsafe.Pointer(_name))
+	defer C.free(unsafe.Pointer(_value))
 	return C.SDL_SetHint(_name, _value) > 0
 }
 
 // GetHint (https://wiki.libsdl.org/SDL_GetHint)
 func GetHint(name string) string {
 	_name := C.CString(name)
-	defer C.SDL_free(unsafe.Pointer(_name))
+	defer C.free(unsafe.Pointer(_name))
 	return C.GoString(C.SDL_GetHint(_name))
 }
 

--- a/sdl/joystick.go
+++ b/sdl/joystick.go
@@ -61,14 +61,14 @@ func (joy *Joystick) GetGUID() JoystickGUID {
 // JoystickGetGUIDString (https://wiki.libsdl.org/SDL_JoystickGetGUIDString)
 func JoystickGetGUIDString(guid JoystickGUID, pszGUID string, cbGUID int) {
 	_pszGUID := C.CString(pszGUID)
-	defer C.SDL_free(unsafe.Pointer(_pszGUID))
+	defer C.free(unsafe.Pointer(_pszGUID))
 	C.SDL_JoystickGetGUIDString(guid.c(), _pszGUID, C.int(cbGUID))
 }
 
 // JoystickGetGUIDFromString (https://wiki.libsdl.org/SDL_JoystickGetGUIDFromString)
 func JoystickGetGUIDFromString(pchGUID string) JoystickGUID {
 	_pchGUID := C.CString(pchGUID)
-	defer C.SDL_free(unsafe.Pointer(_pchGUID))
+	defer C.free(unsafe.Pointer(_pchGUID))
 	return (JoystickGUID)(C.SDL_JoystickGetGUIDFromString(_pchGUID))
 }
 

--- a/sdl/keyboard.go
+++ b/sdl/keyboard.go
@@ -52,7 +52,7 @@ func GetScancodeName(code Scancode) string {
 // GetScancodeFromName (https://wiki.libsdl.org/SDL_GetScancodeFromName)
 func GetScancodeFromName(name string) Scancode {
 	_name := C.CString(name)
-	defer C.SDL_free(unsafe.Pointer(_name))
+	defer C.free(unsafe.Pointer(_name))
 	return (Scancode)(C.SDL_GetScancodeFromName(_name))
 }
 
@@ -64,7 +64,7 @@ func GetKeyName(code Keycode) string {
 // GetKeyFromName (https://wiki.libsdl.org/SDL_GetKeyFromName)
 func GetKeyFromName(name string) Keycode {
 	_name := C.CString(name)
-	defer C.SDL_free(unsafe.Pointer(_name))
+	defer C.free(unsafe.Pointer(_name))
 	return (Keycode)(C.SDL_GetKeyFromName(_name))
 }
 

--- a/sdl/loadso.go
+++ b/sdl/loadso.go
@@ -7,14 +7,14 @@ import "unsafe"
 // LoadObject (https://wiki.libsdl.org/SDL_LoadObject)
 func LoadObject(sofile string) unsafe.Pointer {
 	_sofile := C.CString(sofile)
-	defer C.SDL_free(unsafe.Pointer(_sofile))
+	defer C.free(unsafe.Pointer(_sofile))
 	return (unsafe.Pointer)(C.SDL_LoadObject(_sofile))
 }
 
 // LoadFunction (https://wiki.libsdl.org/SDL_LoadFunction)
 func LoadFunction(handle unsafe.Pointer, name string) unsafe.Pointer {
 	_name := C.CString(name)
-	defer C.SDL_free(unsafe.Pointer(_name))
+	defer C.free(unsafe.Pointer(_name))
 	return (unsafe.Pointer)(C.SDL_LoadFunction(handle, _name))
 }
 

--- a/sdl/log.go
+++ b/sdl/log.go
@@ -113,7 +113,7 @@ func Log(str string, args ...interface{}) {
 	str = fmt.Sprintf(str, args...)
 
 	cstr := C.CString(str)
-	defer C.SDL_free(unsafe.Pointer(cstr))
+	defer C.free(unsafe.Pointer(cstr))
 
 	C._SDL_Log(cstr)
 }
@@ -123,7 +123,7 @@ func LogVerbose(cat int, str string, args ...interface{}) {
 	str = fmt.Sprintf(str, args...)
 
 	cstr := C.CString(str)
-	defer C.SDL_free(unsafe.Pointer(cstr))
+	defer C.free(unsafe.Pointer(cstr))
 
 	C._SDL_LogVerbose(C.int(cat), cstr)
 }
@@ -133,7 +133,7 @@ func LogDebug(cat int, str string, args ...interface{}) {
 	str = fmt.Sprintf(str, args...)
 
 	cstr := C.CString(str)
-	defer C.SDL_free(unsafe.Pointer(cstr))
+	defer C.free(unsafe.Pointer(cstr))
 
 	C._SDL_LogDebug(C.int(cat), cstr)
 }
@@ -143,7 +143,7 @@ func LogInfo(cat int, str string, args ...interface{}) {
 	str = fmt.Sprintf(str, args...)
 
 	cstr := C.CString(str)
-	defer C.SDL_free(unsafe.Pointer(cstr))
+	defer C.free(unsafe.Pointer(cstr))
 
 	C._SDL_LogInfo(C.int(cat), cstr)
 }
@@ -153,7 +153,7 @@ func LogWarn(cat int, str string, args ...interface{}) {
 	str = fmt.Sprintf(str, args...)
 
 	cstr := C.CString(str)
-	defer C.SDL_free(unsafe.Pointer(cstr))
+	defer C.free(unsafe.Pointer(cstr))
 
 	C._SDL_LogWarn(C.int(cat), cstr)
 }
@@ -163,7 +163,7 @@ func LogError(cat int, str string, args ...interface{}) {
 	str = fmt.Sprintf(str, args...)
 
 	cstr := C.CString(str)
-	defer C.SDL_free(unsafe.Pointer(cstr))
+	defer C.free(unsafe.Pointer(cstr))
 
 	C._SDL_LogError(C.int(cat), cstr)
 }
@@ -173,7 +173,7 @@ func LogCritical(cat int, str string, args ...interface{}) {
 	str = fmt.Sprintf(str, args...)
 
 	cstr := C.CString(str)
-	defer C.SDL_free(unsafe.Pointer(cstr))
+	defer C.free(unsafe.Pointer(cstr))
 
 	C._SDL_LogCritical(C.int(cat), cstr)
 }
@@ -183,7 +183,7 @@ func LogMessage(cat int, pri LogPriority, str string, args ...interface{}) {
 	str = fmt.Sprintf(str, args...)
 
 	cstr := C.CString(str)
-	defer C.SDL_free(unsafe.Pointer(cstr))
+	defer C.free(unsafe.Pointer(cstr))
 
 	C._SDL_LogMessage(C.int(cat), C.SDL_LogPriority(pri), cstr)
 }

--- a/sdl/rwops.go
+++ b/sdl/rwops.go
@@ -57,8 +57,8 @@ func (rw *RWops) cptr() *C.SDL_RWops {
 func RWFromFile(file, mode string) *RWops {
 	_file := C.CString(file)
 	_mode := C.CString(mode)
-	defer C.SDL_free(unsafe.Pointer(_file))
-	defer C.SDL_free(unsafe.Pointer(_mode))
+	defer C.free(unsafe.Pointer(_file))
+	defer C.free(unsafe.Pointer(_mode))
 	return (*RWops)(unsafe.Pointer(C.SDL_RWFromFile(_file, _mode)))
 }
 

--- a/sdl_image/sdl_image.go
+++ b/sdl_image/sdl_image.go
@@ -42,7 +42,7 @@ func LoadTyped_RW(src *sdl.RWops, freesrc int, type_ string) (*sdl.Surface, erro
 	_src := (*C.SDL_RWops)(unsafe.Pointer(src))
 	_freesrc := (C.int)(freesrc)
 	_type := C.CString(type_)
-	defer C.SDL_free(unsafe.Pointer(_type))
+	defer C.free(unsafe.Pointer(_type))
 	_surface := C.IMG_LoadTyped_RW(_src, _freesrc, _type)
 	if _surface == nil {
 		return nil, GetError()
@@ -52,7 +52,7 @@ func LoadTyped_RW(src *sdl.RWops, freesrc int, type_ string) (*sdl.Surface, erro
 
 func Load(file string) (*sdl.Surface, error) {
 	_file := C.CString(file)
-	defer C.SDL_free(unsafe.Pointer(_file))
+	defer C.free(unsafe.Pointer(_file))
 	_surface := C.IMG_Load(_file)
 	if _surface == nil {
 		return nil, GetError()
@@ -73,7 +73,7 @@ func Load_RW(src *sdl.RWops, freesrc int) (*sdl.Surface, error) {
 func LoadTexture(renderer *sdl.Renderer, file string) (*sdl.Texture, error) {
 	_renderer := (*C.SDL_Renderer)(unsafe.Pointer(renderer))
 	_file := C.CString(file)
-	defer C.SDL_free(unsafe.Pointer(_file))
+	defer C.free(unsafe.Pointer(_file))
 	_surface := C.IMG_LoadTexture(_renderer, _file)
 	if _surface == nil {
 		return nil, GetError()
@@ -299,7 +299,7 @@ func LoadWEBP_RW(src *sdl.RWops) (*sdl.Surface, error) {
 
 func ReadXPMFromArray(xpm string) (*sdl.Surface, error) {
 	_xpm := C.CString(xpm)
-	C.SDL_free(unsafe.Pointer(_xpm))
+	C.free(unsafe.Pointer(_xpm))
 	_surface := C.IMG_ReadXPMFromArray(&_xpm)
 	if _surface == nil {
 		return nil, GetError()
@@ -310,7 +310,7 @@ func ReadXPMFromArray(xpm string) (*sdl.Surface, error) {
 func SavePNG(surface *sdl.Surface, file string) error {
 	_surface := (*C.SDL_Surface)(unsafe.Pointer(surface))
 	_file := C.CString(file)
-	C.SDL_free(unsafe.Pointer(_file))
+	C.free(unsafe.Pointer(_file))
 	_ret := C.IMG_SavePNG(_surface, _file)
 	if _ret < 0 {
 		return GetError()

--- a/sdl_mixer/sdl_mixer.go
+++ b/sdl_mixer/sdl_mixer.go
@@ -88,15 +88,15 @@ func LoadWAV_RW(src *sdl.RWops, freesrc int) *Chunk {
 
 func LoadWAV(file string) *Chunk {
 	_file := C.CString(file)
-	defer C.SDL_free(unsafe.Pointer(_file))
+	defer C.free(unsafe.Pointer(_file))
 	_rb := C.CString("rb")
-	defer C.SDL_free(unsafe.Pointer(_rb))
+	defer C.free(unsafe.Pointer(_rb))
 	return (*Chunk)(unsafe.Pointer(C.Mix_LoadWAV_RW(C.SDL_RWFromFile(_file, _rb), 1)))
 }
 
 func LoadMUS(file string) *Music {
 	_file := C.CString(file)
-	defer C.SDL_free(unsafe.Pointer(_file))
+	defer C.free(unsafe.Pointer(_file))
 	return (*Music)(unsafe.Pointer(C.Mix_LoadMUS(_file)))
 }
 
@@ -368,7 +368,7 @@ func MusicPlaying() bool {
 
 func SetMusicCMD(command string) bool {
 	_command := C.CString(command)
-	defer C.SDL_free(unsafe.Pointer(_command))
+	defer C.free(unsafe.Pointer(_command))
 	return int(C.Mix_SetMusicCMD(_command)) == 0
 }
 
@@ -383,7 +383,7 @@ func GetSynchroValue() int {
 
 func SetSoundFonts(paths string) bool {
 	_paths := C.CString(paths)
-	defer C.SDL_free(unsafe.Pointer(_paths))
+	defer C.free(unsafe.Pointer(_paths))
 	return int(C.Mix_SetSoundFonts(_paths)) == 0
 }
 

--- a/sdl_ttf/sdl_ttf.go
+++ b/sdl_ttf/sdl_ttf.go
@@ -11,7 +11,6 @@ package ttf
 import "C"
 import "github.com/veandco/go-sdl2/sdl"
 import "unsafe"
-import "runtime"
 import "errors"
 
 //Font Hinting Types
@@ -57,7 +56,7 @@ func GetError() error {
 
 func SetError(err string) {
 	_err := C.CString(err)
-	defer C.SDL_free(unsafe.Pointer(_err))
+	defer C.free(unsafe.Pointer(_err))
 	C.Do_TTF_SetError(_err)
 }
 
@@ -71,7 +70,7 @@ func ByteSwappedUnicode(swap bool) {
 
 func OpenFont(file string, size int) (*Font, error) {
 	_file := C.CString(file)
-	defer C.SDL_free(unsafe.Pointer(_file))
+	defer C.free(unsafe.Pointer(_file))
 	_size := (C.int)(size)
 	f := (*C.TTF_Font)(C.TTF_OpenFont(_file, _size))
 
@@ -83,7 +82,7 @@ func OpenFont(file string, size int) (*Font, error) {
 
 func OpenFontIndex(file string, size int, index int) (*Font, error) {
 	_file := C.CString(file)
-	defer C.SDL_free(unsafe.Pointer(_file))
+	defer C.free(unsafe.Pointer(_file))
 	_size := (C.int)(size)
 	_index := (C.long)(index)
 	f := (*C.TTF_Font)(C.TTF_OpenFontIndex(_file, _size, _index))
@@ -96,16 +95,15 @@ func OpenFontIndex(file string, size int, index int) (*Font, error) {
 
 func (f *Font) RenderText_Solid(text string, color sdl.Color) *sdl.Surface {
 	_text := C.CString(text)
-	defer C.SDL_free(unsafe.Pointer(_text))
+	defer C.free(unsafe.Pointer(_text))
 	_c := C.SDL_Color{C.Uint8(color.R), C.Uint8(color.G), C.Uint8(color.B), C.Uint8(color.A)}
 	surface := (*sdl.Surface)(unsafe.Pointer(C.TTF_RenderText_Solid(f.f, _text, _c)))
 	return surface
 }
 
 func (f *Font) RenderText_Shaded(text string, fg, bg sdl.Color) *sdl.Surface {
-	runtime.LockOSThread()
 	_text := C.CString(text)
-	defer C.SDL_free(unsafe.Pointer(_text))
+	defer C.free(unsafe.Pointer(_text))
 	_fg := C.SDL_Color{C.Uint8(fg.R), C.Uint8(fg.G), C.Uint8(fg.B), C.Uint8(fg.A)}
 	_bg := C.SDL_Color{C.Uint8(bg.R), C.Uint8(bg.G), C.Uint8(bg.B), C.Uint8(bg.A)}
 	surface := (*sdl.Surface)(unsafe.Pointer(C.TTF_RenderText_Shaded(f.f, _text, _fg, _bg)))
@@ -114,7 +112,7 @@ func (f *Font) RenderText_Shaded(text string, fg, bg sdl.Color) *sdl.Surface {
 
 func (f *Font) RenderText_Blended(text string, color sdl.Color) *sdl.Surface {
 	_text := C.CString(text)
-	defer C.SDL_free(unsafe.Pointer(_text))
+	defer C.free(unsafe.Pointer(_text))
 	_c := C.SDL_Color{C.Uint8(color.R), C.Uint8(color.G), C.Uint8(color.B), C.Uint8(color.A)}
 	surface := (*sdl.Surface)(unsafe.Pointer(C.TTF_RenderText_Blended(f.f, _text, _c)))
 	return surface
@@ -174,6 +172,5 @@ func (f *Font) FaceIsFixedWidth() bool {
 func (f *Font) FaceFamilyName() string {
 	_fname := C.TTF_FontFaceFamilyName(f.f)
 	fname := C.GoString(_fname)
-	C.SDL_free(unsafe.Pointer(_fname))
 	return fname
 }


### PR DESCRIPTION
This should fix the problem with issue #78, and fixes the misuse of C.SDL_free in other files as well.

Specifially, C.SDL_free should not be called on strings created with C.CString, C.free should be used instead.

Additionally, a missing SDL_free has been added to clipboard.go. An excess SDL_free has been removed from the FaceFamilyName method in sdl_ttf.go.