### PR TITLE
sdl.Rect: fix 'Empty() bool'

### DIFF
--- a/sdl/rect.go
+++ b/sdl/rect.go
@@ -28,10 +28,7 @@ func (r *Rect) cptr() *C.SDL_Rect {
 
 // Rect (https://wiki.libsdl.org/SDL_RectEmpty)
 func (r *Rect) Empty() bool {
-	if (r != nil) || (r.W <= 0) || (r.H <= 0) {
-		return true
-	}
-	return false
+	return r == nil || r.W <= 0 || r.H <= 0
 }
 
 // Rect (https://wiki.libsdl.org/SDL_RectEquals)

--- a/sdl/rect_test.go
+++ b/sdl/rect_test.go
@@ -1,0 +1,24 @@
+package sdl
+
+import (
+	"testing"
+)
+
+func TestRectEmpty(t *testing.T) {
+	var tests = []struct {
+		want bool
+		r    *Rect
+	}{
+		{want: true, r: &Rect{}},
+		{want: true, r: &Rect{W: 1}},
+		{want: true, r: &Rect{H: 1}},
+		{want: true, r: nil},
+		{want: false, r: &Rect{W: 1, H: 1}},
+	}
+
+	for _, test := range tests {
+		if got := test.r.Empty(); got != test.want {
+			t.Errorf("%#v.Empty() = %v - want %v", test.r, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
The behavior of Rect.Empty was different than what is described in https://wiki.libsdl.org/SDL_RectEmpty
After this change Rect.Empty will no longer crash when called on a nil pointer.
Additionally the method will return the correct value.