### PR TITLE
change data-types of structures which are used to interact with C.

### DIFF
--- a/sdl/render.go
+++ b/sdl/render.go
@@ -37,8 +37,8 @@ type RendererInfoData struct {
 	Flags             uint32
 	NumTextureFormats uint32
 	TextureFormats    [16]int32
-	MaxTextureWidth   int
-	MaxTextureHeight  int
+	MaxTextureWidth   int32
+	MaxTextureHeight  int32
 }
 
 // RendererFlip (https://wiki.libsdl.org/SDL_RendererFlip)

--- a/sdl/video.go
+++ b/sdl/video.go
@@ -87,9 +87,9 @@ const (
 // DisplayMode (https://wiki.libsdl.org/SDL_DisplayMode)
 type DisplayMode struct {
 	Format      uint32
-	W           int
-	H           int
-	RefreshRate int
+	W           int32
+	H           int32
+	RefreshRate int32
 	DriverData  unsafe.Pointer
 }
 


### PR DESCRIPTION
SDL uses the datatype "int" to mean 32bit fields. However, 64bit go uses 64bits for an int.
In the case of the DisplayMode this caused the following output:

    display=0 mode=0 format=370546692 width=253403071664, height=46087472 refresh=0

After changing the relevant variables in DisplayMode to int32 the result is as follows:

    display=0 mode=0 format=370546692 width=1920, height=1200 refresh=59

This fix also includes aligning RendererInfoData.{MaxTextureWidth,MaxTextureHeight}

A short grep revealed that the following fields and types might also be affected:

    AudioSpec.Freq
    AudioCVT.Needed
    AudioCVT.Len
    AudioCVT.LenCVT
    AudioCVT.LenMult
    AudioCVT.FilterIndex
    PixelFormat.RefCount
    Palette.Ncolors
    Palette.RefCount
    Surface.Pitch
    Surface.Locked
    Surface.RefCount
    X11Info.Window
    SW_YUVTexture.W
    SW_YUVTexture.H
    SW_YUVTexture.ColorTab
    
    type AudioStatus uint
    type RendererFlip uint
    type RendererFlip uint
    type ErrorCode uint
    type MusicType int
    type Fading int


I think it would generally be a good idea to use int32/uint32 for all fields which are defined as int/uint in the SDL2 API.
Do you agree ?

Kind regards and thanks for this project!
-Phil