### PR TITLE
Make sdl.Init idiomatic with respect to errors

### DIFF
--- a/examples/opengl.go
+++ b/examples/opengl.go
@@ -17,8 +17,8 @@ func main() {
 	var running bool
 	var err error
 
-	if 0 != sdl.Init(sdl.INIT_EVERYTHING) {
-		panic(sdl.GetError())
+	if err = sdl.Init(sdl.INIT_EVERYTHING); err != nil {
+		panic(err)
 	}
 	defer sdl.Quit()
 	window, err = sdl.CreateWindow(winTitle, sdl.WINDOWPOS_UNDEFINED, sdl.WINDOWPOS_UNDEFINED,

--- a/examples/opengl3.go
+++ b/examples/opengl3.go
@@ -60,8 +60,8 @@ func main() {
 	var running bool
 	var err error
 	runtime.LockOSThread()
-	if 0 != sdl.Init(sdl.INIT_EVERYTHING) {
-		panic(sdl.GetError())
+	if err = sdl.Init(sdl.INIT_EVERYTHING); err != nil {
+		panic(err)
 	}
 	defer sdl.Quit()
 	window, err = sdl.CreateWindow(winTitle, sdl.WINDOWPOS_UNDEFINED,

--- a/sdl/sdl.go
+++ b/sdl/sdl.go
@@ -23,8 +23,11 @@ const (
 )
 
 // Init (https://wiki.libsdl.org/SDL_Init)
-func Init(flags uint32) int {
-	return int(C.SDL_Init(C.Uint32(flags)))
+func Init(flags uint32) error {
+	if C.SDL_Init(C.Uint32(flags)) != 0 {
+		return GetError()
+	}
+	return nil
 }
 
 // Quit (https://wiki.libsdl.org/SDL_Quit)

--- a/sdl/sdl_test.go
+++ b/sdl/sdl_test.go
@@ -13,8 +13,8 @@ func TestInitQuit(t *testing.T) {
 			// FreeBSD does not support the haptic subsystem
 			continue
 		}
-		if Init(subs[i]) != 0 {
-			t.Errorf("Error on Init(%d): %s", subs[i], GetError())
+		if err := Init(subs[i]); err != nil {
+			t.Errorf("Error on Init(%d): %s", subs[i], err)
 		}
 		if WasInit(subs[i]) != subs[i] {
 			t.Errorf("Init(%d): subsystem not initialized", subs[i])


### PR DESCRIPTION
Init should return an error if one occurred, not an int.