### PR TITLE
structure layout verification and other small fixes

### DIFF
--- a/sdl/audio.go
+++ b/sdl/audio.go
@@ -58,7 +58,7 @@ type AudioStatus uint
 
 // AudioSpec (https://wiki.libsdl.org/SDL_AudioSpec)
 type AudioSpec struct {
-	Freq     int
+	Freq     int32
 	Format   AudioFormat
 	Channels uint8
 	Silence  uint8
@@ -68,21 +68,23 @@ type AudioSpec struct {
 	Callback AudioCallback
 	UserData unsafe.Pointer
 }
+type cAudioSpec C.SDL_AudioSpec
 
 // AudioCVT (https://wiki.libsdl.org/SDL_AudioCVT)
 type AudioCVT struct {
-	Needed      int
+	Needed      int32
 	SrcFormat   AudioFormat
 	DstFormat   AudioFormat
 	RateIncr    float64
 	Buf         *uint8
-	Len         int
-	LenCVT      int
-	LenMult     int
+	Len         int32
+	LenCVT      int32
+	LenMult     int32
 	LenRatio    float64
-	filters     [10]AudioFilter
-	FilterIndex int
+	filters     [10]AudioFilter // internal
+	filterIndex int32           // internal
 }
+type cAudioCVT C.SDL_AudioCVT
 
 func (fmt AudioFormat) c() C.SDL_AudioFormat {
 	return C.SDL_AudioFormat(fmt)

--- a/sdl/audio.go
+++ b/sdl/audio.go
@@ -270,7 +270,7 @@ func UnlockAudioDevice(dev AudioDeviceID) {
 
 // CloseAudio (https://wiki.libsdl.org/SDL_CloseAudio)
 func CloseAudio() {
-	C.SDL_UnlockAudio()
+	C.SDL_CloseAudio()
 }
 
 // CloseAudioDevice (https://wiki.libsdl.org/SDL_CloseAudioDevice)

--- a/sdl/events.go
+++ b/sdl/events.go
@@ -157,7 +157,6 @@ type TextEditingEvent struct {
 	Start     int32
 	Length    int32
 }
-
 type cTextEditingEvent C.SDL_TextEditingEvent
 
 // TextInputEvent (https://wiki.libsdl.org/SDL_TextInputEvent)
@@ -221,6 +220,7 @@ type JoyAxisEvent struct {
 	Value     int16
 	_         uint16 // padding
 }
+type cJoyAxisEvent C.SDL_JoyAxisEvent
 
 // JoyBallEvent (https://wiki.libsdl.org/SDL_JoyBallEvent)
 type JoyBallEvent struct {
@@ -234,6 +234,7 @@ type JoyBallEvent struct {
 	XRel      int16
 	YRel      int16
 }
+type cJoyBallEvent C.SDL_JoyBallEvent
 
 // JoyHatEvent (https://wiki.libsdl.org/SDL_JoyHatEvent)
 type JoyHatEvent struct {
@@ -245,6 +246,7 @@ type JoyHatEvent struct {
 	_         uint8 // padding
 	_         uint8 // padding
 }
+type cJoyHatEvent C.SDL_JoyHatEvent
 
 // JoyButtonEvent (https://wiki.libsdl.org/SDL_JoyButtonEvent)
 type JoyButtonEvent struct {
@@ -256,6 +258,7 @@ type JoyButtonEvent struct {
 	_         uint8 // padding
 	_         uint8 // padding
 }
+type cJoyButtonEvent C.SDL_JoyButtonEvent
 
 type JoyDeviceEvent struct {
 	Type      uint32
@@ -274,6 +277,7 @@ type ControllerAxisEvent struct {
 	Value     int16
 	_         uint16 // padding
 }
+type cControllerAxisEvent C.SDL_ControllerAxisEvent
 
 type ControllerButtonEvent struct {
 	Type      uint32
@@ -284,12 +288,14 @@ type ControllerButtonEvent struct {
 	_         uint8 // padding
 	_         uint8 // padding
 }
+type cControllerButtonEvent C.SDL_ControllerButtonEvent
 
 type ControllerDeviceEvent struct {
 	Type      uint32
 	Timestamp uint32
 	Which     JoystickID
 }
+type cControllerDeviceEvent C.SDL_ControllerDeviceEvent
 
 // TouchFingerEvent (https://wiki.libsdl.org/SDL_TouchFingerEvent)
 type TouchFingerEvent struct {
@@ -303,6 +309,7 @@ type TouchFingerEvent struct {
 	DY        float32
 	Pressure  float32
 }
+type cTouchFingerEvent C.SDL_TouchFingerEvent
 
 // MultiGestureEvent (https://wiki.libsdl.org/SDL_MultiGestureEvent)
 type MultiGestureEvent struct {
@@ -316,6 +323,7 @@ type MultiGestureEvent struct {
 	NumFingers uint16
 	_          uint16 // padding
 }
+type cMultiGestureEvent C.SDL_MultiGestureEvent
 
 // DollarGestureEvent (https://wiki.libsdl.org/SDL_DollarGestureEvent)
 type DollarGestureEvent struct {
@@ -328,6 +336,7 @@ type DollarGestureEvent struct {
 	X          float32
 	Y          float32
 }
+type cDollarGestureEvent C.SDL_DollarGestureEvent
 
 // DropEvent (https://wiki.libsdl.org/SDL_DropEvent)
 type DropEvent struct {
@@ -335,6 +344,7 @@ type DropEvent struct {
 	Timestamp uint32
 	file      unsafe.Pointer
 }
+type cDropEvent C.SDL_DropEvent
 
 type RenderEvent struct {
 	Type      uint32
@@ -366,6 +376,7 @@ type UserEvent struct {
 	Data1     unsafe.Pointer
 	Data2     unsafe.Pointer
 }
+type cUserEvent C.SDL_UserEvent
 
 // SysWMEvent (https://wiki.libsdl.org/SDL_SysWMEvent)
 type SysWMEvent struct {
@@ -373,6 +384,7 @@ type SysWMEvent struct {
 	Timestamp uint32
 	msg       unsafe.Pointer
 }
+type cSysWMEvent C.SDL_SysWMEvent
 
 type EventAction C.SDL_eventaction
 

--- a/sdl/events.go
+++ b/sdl/events.go
@@ -100,8 +100,8 @@ const (
 type Event interface{}
 
 type CEvent struct {
-	Type     uint32
-	padding1 [52]byte
+	Type uint32
+	_    [52]byte // padding
 }
 
 type CommonEvent struct {
@@ -115,12 +115,15 @@ type WindowEvent struct {
 	Timestamp uint32
 	WindowID  uint32
 	Event     uint8
-	padding1  uint8
-	padding2  uint8
-	padding3  uint8
+	_         uint8 // padding
+	_         uint8 // padding
+	_         uint8 // padding
 	Data1     int32
 	Data2     int32
 }
+type cWindowEvent C.SDL_WindowEvent
+
+//TODO: Key{Up,Down}Event only differ in 'Type' - a boolean field would be enough to distinguish up/down events
 
 type KeyDownEvent struct {
 	Type      uint32
@@ -128,10 +131,11 @@ type KeyDownEvent struct {
 	WindowID  uint32
 	State     uint8
 	Repeat    uint8
-	padding1  uint8
-	padding2  uint8
+	_         uint8 // padding
+	_         uint8 // padding
 	Keysym    Keysym
 }
+type cKeyboardEvent C.SDL_KeyboardEvent
 
 type KeyUpEvent struct {
 	Type      uint32
@@ -139,8 +143,8 @@ type KeyUpEvent struct {
 	WindowID  uint32
 	State     uint8
 	Repeat    uint8
-	padding1  uint8
-	padding2  uint8
+	_         uint8 // padding
+	_         uint8 // padding
 	Keysym    Keysym
 }
 
@@ -154,6 +158,8 @@ type TextEditingEvent struct {
 	Length    int32
 }
 
+type cTextEditingEvent C.SDL_TextEditingEvent
+
 // TextInputEvent (https://wiki.libsdl.org/SDL_TextInputEvent)
 type TextInputEvent struct {
 	Type      uint32
@@ -161,6 +167,7 @@ type TextInputEvent struct {
 	WindowID  uint32
 	Text      [C.SDL_TEXTINPUTEVENT_TEXT_SIZE]byte
 }
+type cTextInputEvent C.SDL_TextInputEvent
 
 // MouseMotionEvent (https://wiki.libsdl.org/SDL_MouseMotionEvent)
 type MouseMotionEvent struct {
@@ -174,6 +181,7 @@ type MouseMotionEvent struct {
 	XRel      int32
 	YRel      int32
 }
+type cMouseMotionEvent C.SDL_MouseMotionEvent
 
 // MouseButtonEvent (https://wiki.libsdl.org/SDL_MouseButtonEvent)
 type MouseButtonEvent struct {
@@ -183,11 +191,12 @@ type MouseButtonEvent struct {
 	Which     uint32
 	Button    uint8
 	State     uint8
-	padding1  uint8
-	padding2  uint8
+	_         uint8 // padding
+	_         uint8 // padding
 	X         int32
 	Y         int32
 }
+type cMouseButtonEvent C.SDL_MouseButtonEvent
 
 // MouseWheelEvent (https://wiki.libsdl.org/SDL_MouseWheelEvent)
 type MouseWheelEvent struct {
@@ -198,6 +207,7 @@ type MouseWheelEvent struct {
 	X         int32
 	Y         int32
 }
+type cMouseWheelEvent C.SDL_MouseWheelEvent
 
 // JoyAxisEvent (https://wiki.libsdl.org/SDL_JoyAxisEvent)
 type JoyAxisEvent struct {
@@ -205,11 +215,11 @@ type JoyAxisEvent struct {
 	Timestamp uint32
 	Which     JoystickID
 	Axis      uint8
-	padding1  uint8
-	padding2  uint8
-	padding3  uint8
+	_         uint8 // padding
+	_         uint8 // padding
+	_         uint8 // padding
 	Value     int16
-	padding4  uint16
+	_         uint16 // padding
 }
 
 // JoyBallEvent (https://wiki.libsdl.org/SDL_JoyBallEvent)
@@ -218,9 +228,9 @@ type JoyBallEvent struct {
 	Timestamp uint32
 	Which     JoystickID
 	Ball      uint8
-	padding1  uint8
-	padding2  uint8
-	padding3  uint8
+	_         uint8 // padding
+	_         uint8 // padding
+	_         uint8 // padding
 	XRel      int16
 	YRel      int16
 }
@@ -232,8 +242,8 @@ type JoyHatEvent struct {
 	Which     JoystickID
 	Hat       uint8
 	Value     uint8
-	padding1  uint8
-	padding2  uint8
+	_         uint8 // padding
+	_         uint8 // padding
 }
 
 // JoyButtonEvent (https://wiki.libsdl.org/SDL_JoyButtonEvent)
@@ -243,8 +253,8 @@ type JoyButtonEvent struct {
 	Which     JoystickID
 	Button    uint8
 	State     uint8
-	padding1  uint8
-	padding2  uint8
+	_         uint8 // padding
+	_         uint8 // padding
 }
 
 type JoyDeviceEvent struct {
@@ -258,11 +268,11 @@ type ControllerAxisEvent struct {
 	Timestamp uint32
 	Which     JoystickID
 	Axis      uint8
-	padding1  uint8
-	padding2  uint8
-	padding3  uint8
+	_         uint8 // padding
+	_         uint8 // padding
+	_         uint8
 	Value     int16
-	padding4  uint16
+	_         uint16 // padding
 }
 
 type ControllerButtonEvent struct {
@@ -271,8 +281,8 @@ type ControllerButtonEvent struct {
 	Which     JoystickID
 	Button    uint8
 	State     uint8
-	padding1  uint8
-	padding2  uint8
+	_         uint8 // padding
+	_         uint8 // padding
 }
 
 type ControllerDeviceEvent struct {
@@ -304,7 +314,7 @@ type MultiGestureEvent struct {
 	X          float32
 	Y          float32
 	NumFingers uint16
-	padding    uint16
+	_          uint16 // padding
 }
 
 // DollarGestureEvent (https://wiki.libsdl.org/SDL_DollarGestureEvent)

--- a/sdl/pixels.go
+++ b/sdl/pixels.go
@@ -30,11 +30,12 @@ type cPixelFormat C.SDL_PixelFormat
 
 // Palette (https://wiki.libsdl.org/SDL_Palette)
 type Palette struct {
-	Ncolors  int
+	Ncolors  int32
 	Colors   *Color
 	Version  uint32
-	RefCount int
+	RefCount int32
 }
+type cPalette C.SDL_Palette
 
 // Color (https://wiki.libsdl.org/SDL_Color)
 type Color struct {

--- a/sdl/pixels.go
+++ b/sdl/pixels.go
@@ -8,9 +8,9 @@ import "unsafe"
 type PixelFormat struct {
 	Format        uint32
 	Palette       *Palette
-	BitsPerPixels uint8
+	BitsPerPixel  uint8
 	BytesPerPixel uint8
-	padding       [2]uint8
+	_             [2]uint8 // padding
 	Rmask         uint32
 	Gmask         uint32
 	Bmask         uint32
@@ -23,9 +23,10 @@ type PixelFormat struct {
 	Gshift        uint8
 	Bshift        uint8
 	Ashift        uint8
-	RefCount      int
+	RefCount      int32
 	Next          *PixelFormat
 }
+type cPixelFormat C.SDL_PixelFormat
 
 // Palette (https://wiki.libsdl.org/SDL_Palette)
 type Palette struct {

--- a/sdl/render.go
+++ b/sdl/render.go
@@ -28,6 +28,7 @@ type RendererInfo struct {
 	Name string
 	RendererInfoData
 }
+
 type cRendererInfo struct {
 	Name *C.char
 	RendererInfoData
@@ -40,6 +41,7 @@ type RendererInfoData struct {
 	MaxTextureWidth   int32
 	MaxTextureHeight  int32
 }
+type realcRendererInfo C.SDL_RendererInfo
 
 // RendererFlip (https://wiki.libsdl.org/SDL_RendererFlip)
 type RendererFlip uint

--- a/sdl/struct_test.go
+++ b/sdl/struct_test.go
@@ -6,12 +6,31 @@ import (
 	"testing"
 )
 
-func TestVersionStruct(t *testing.T)     { testStructEquality(t, Version{}, cVersion{}) }
-func TestPixelFormatStruct(t *testing.T) { testStructEquality(t, PixelFormat{}, cPixelFormat{}) }
-func TestSurfaceStruct(t *testing.T)     { testStructEquality(t, Surface{}, cSurface{}) }
+func TestStructKeyDownEvent(t *testing.T) { testStructEquality(t, KeyDownEvent{}, cKeyboardEvent{}) }
+func TestStructKeyUpEvent(t *testing.T)   { testStructEquality(t, KeyUpEvent{}, cKeyboardEvent{}) }
+func TestStructMouseButtonEvent(t *testing.T) {
+	testStructEquality(t, MouseButtonEvent{}, cMouseButtonEvent{})
+}
+func TestStructMouseMotionEvent(t *testing.T) {
+	testStructEquality(t, MouseMotionEvent{}, cMouseMotionEvent{})
+}
+func TestStructMouseWheelEvent(t *testing.T) {
+	testStructEquality(t, MouseWheelEvent{}, cMouseWheelEvent{})
+}
+func TestStructTextEditingEvent(t *testing.T) {
+	testStructEquality(t, TextEditingEvent{}, cTextEditingEvent{})
+}
+func TestStructTextInputEvent(t *testing.T) {
+	testStructEquality(t, TextInputEvent{}, cTextInputEvent{})
+}
 
-//func TestSysWmInfoSize(t *testing.T) { testStructEquality(t, SysWMInfo{}, cSysWMinfo{}) }
-// WindowEvent
+func TestStructPixelFormat(t *testing.T) { testStructEquality(t, PixelFormat{}, cPixelFormat{}) }
+func TestStructSurface(t *testing.T)     { testStructEquality(t, Surface{}, cSurface{}) }
+func TestStructVersion(t *testing.T)     { testStructEquality(t, Version{}, cVersion{}) }
+func TestStructWindowEvent(t *testing.T) { testStructEquality(t, WindowEvent{}, cWindowEvent{}) }
+
+//TODO
+//func TestStructSysWmInfo(t *testing.T)   { testStructEquality(t, SysWMInfo{}, cSysWMinfo{}) }
 
 func testStructEquality(t *testing.T, a, b interface{}) {
 	ta, tb := reflect.TypeOf(a), reflect.TypeOf(b)

--- a/sdl/struct_test.go
+++ b/sdl/struct_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 )
 
-func TestVersionSize(t *testing.T) { testStructEquality(t, Version{}, cVersion{}) }
+func TestVersionSize(t *testing.T)     { testStructEquality(t, Version{}, cVersion{}) }
+func TestPixelFormatSize(t *testing.T) { testStructEquality(t, PixelFormat{}, cPixelFormat{}) }
 
 //func TestSysWmInfoSize(t *testing.T) { testStructEquality(t, SysWMInfo{}, cSysWMinfo{}) }
-// PixelFormat
 // Surface
 // WindowEvent
 

--- a/sdl/struct_test.go
+++ b/sdl/struct_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 )
 
-func TestVersionSize(t *testing.T)     { testStructEquality(t, Version{}, cVersion{}) }
-func TestPixelFormatSize(t *testing.T) { testStructEquality(t, PixelFormat{}, cPixelFormat{}) }
+func TestVersionStruct(t *testing.T)     { testStructEquality(t, Version{}, cVersion{}) }
+func TestPixelFormatStruct(t *testing.T) { testStructEquality(t, PixelFormat{}, cPixelFormat{}) }
+func TestSurfaceStruct(t *testing.T)     { testStructEquality(t, Surface{}, cSurface{}) }
 
 //func TestSysWmInfoSize(t *testing.T) { testStructEquality(t, SysWMInfo{}, cSysWMinfo{}) }
-// Surface
 // WindowEvent
 
 func testStructEquality(t *testing.T, a, b interface{}) {

--- a/sdl/struct_test.go
+++ b/sdl/struct_test.go
@@ -6,55 +6,54 @@ import (
 	"testing"
 )
 
-// TODO: AudioCVT is a packed struct in C - proper conversion needs some more work
-// func TestStructAudioCVT(t *testing.T)  { testStructEq(t, AudioCVT{}, cAudioCVT{}) }
-func TestStructAudioSpec(t *testing.T)   { testStructEq(t, AudioSpec{}, cAudioSpec{}) }
-func TestStructDisplayMode(t *testing.T) { testStructEq(t, DisplayMode{}, cDisplayMode{}) }
+func TestStructABI(t *testing.T) {
+	var tests = []struct {
+		gStruct interface{}
+		cStruct interface{}
+	}{
+		{AudioSpec{}, cAudioSpec{}},
+		// TODO: AudioCVT is a packed struct in C - proper conversion needs some more work
+		//{ AudioCVT{}, cAudioCVT{} },
+		{DisplayMode{}, cDisplayMode{}},
 
-// EVENTS
+		// EVENTS
+		{KeyDownEvent{}, cKeyboardEvent{}},
+		{KeyUpEvent{}, cKeyboardEvent{}},
+		{MouseButtonEvent{}, cMouseButtonEvent{}},
+		{MouseMotionEvent{}, cMouseMotionEvent{}},
+		{MouseWheelEvent{}, cMouseWheelEvent{}},
+		{TextEditingEvent{}, cTextEditingEvent{}},
+		{TextInputEvent{}, cTextInputEvent{}},
+		{JoyAxisEvent{}, cJoyAxisEvent{}},
+		{JoyBallEvent{}, cJoyBallEvent{}},
+		{JoyHatEvent{}, cJoyHatEvent{}},
+		{JoyButtonEvent{}, cJoyButtonEvent{}},
+		{ControllerAxisEvent{}, cControllerAxisEvent{}},
+		{ControllerButtonEvent{}, cControllerButtonEvent{}},
+		{ControllerDeviceEvent{}, cControllerDeviceEvent{}},
+		{TouchFingerEvent{}, cTouchFingerEvent{}},
+		{MultiGestureEvent{}, cMultiGestureEvent{}},
+		{DollarGestureEvent{}, cDollarGestureEvent{}},
+		{DropEvent{}, cDropEvent{}},
+		{UserEvent{}, cUserEvent{}},
+		{SysWMEvent{}, cSysWMEvent{}},
 
-func TestStructKeyDown(t *testing.T)     { testStructEq(t, KeyDownEvent{}, cKeyboardEvent{}) }
-func TestStructKeyUp(t *testing.T)       { testStructEq(t, KeyUpEvent{}, cKeyboardEvent{}) }
-func TestStructMouseButton(t *testing.T) { testStructEq(t, MouseButtonEvent{}, cMouseButtonEvent{}) }
-func TestStructMouseMotion(t *testing.T) { testStructEq(t, MouseMotionEvent{}, cMouseMotionEvent{}) }
-func TestStructMouseWheel(t *testing.T)  { testStructEq(t, MouseWheelEvent{}, cMouseWheelEvent{}) }
-func TestStructTextEditing(t *testing.T) { testStructEq(t, TextEditingEvent{}, cTextEditingEvent{}) }
-func TestStructTextInput(t *testing.T)   { testStructEq(t, TextInputEvent{}, cTextInputEvent{}) }
-func TestStructJoyAxis(t *testing.T)     { testStructEq(t, JoyAxisEvent{}, cJoyAxisEvent{}) }
-func TestStructJoyBall(t *testing.T)     { testStructEq(t, JoyBallEvent{}, cJoyBallEvent{}) }
-func TestStructJoyHat(t *testing.T)      { testStructEq(t, JoyHatEvent{}, cJoyHatEvent{}) }
-func TestStructJoyButton(t *testing.T)   { testStructEq(t, JoyButtonEvent{}, cJoyButtonEvent{}) }
-func TestStructControllerAxis(t *testing.T) {
-	testStructEq(t, ControllerAxisEvent{}, cControllerAxisEvent{})
+		{Palette{}, cPalette{}},
+		{PixelFormat{}, cPixelFormat{}},
+		{Surface{}, cSurface{}},
+		{Version{}, cVersion{}},
+		{WindowEvent{}, cWindowEvent{}},
+
+		// TODO: embedded structures make testing difficult
+		// { SysWMInfo{}, cSysWMinfo{} },
+		// { RendererInfo{}, realcRendererInfo{} },
+	}
+
+	for _, test := range tests {
+		testStructABI(t, test.gStruct, test.cStruct)
+	}
 }
-func TestStructControllerBtn(t *testing.T) {
-	testStructEq(t, ControllerButtonEvent{}, cControllerButtonEvent{})
-}
-func TestStructControllerDev(t *testing.T) {
-	testStructEq(t, ControllerDeviceEvent{}, cControllerDeviceEvent{})
-}
-func TestStructTouchFinger(t *testing.T)  { testStructEq(t, TouchFingerEvent{}, cTouchFingerEvent{}) }
-func TestStructMultiGesture(t *testing.T) { testStructEq(t, MultiGestureEvent{}, cMultiGestureEvent{}) }
-func TestStructDollarGesture(t *testing.T) {
-	testStructEq(t, DollarGestureEvent{}, cDollarGestureEvent{})
-}
-func TestStructDrop(t *testing.T)  { testStructEq(t, DropEvent{}, cDropEvent{}) }
-func TestStructUser(t *testing.T)  { testStructEq(t, UserEvent{}, cUserEvent{}) }
-func TestStructSysWM(t *testing.T) { testStructEq(t, SysWMEvent{}, cSysWMEvent{}) }
-
-// END OF EVENTS
-
-func TestStructPalette(t *testing.T)     { testStructEq(t, Palette{}, cPalette{}) }
-func TestStructPixelFormat(t *testing.T) { testStructEq(t, PixelFormat{}, cPixelFormat{}) }
-func TestStructSurface(t *testing.T)     { testStructEq(t, Surface{}, cSurface{}) }
-func TestStructVersion(t *testing.T)     { testStructEq(t, Version{}, cVersion{}) }
-func TestStructWindowEvent(t *testing.T) { testStructEq(t, WindowEvent{}, cWindowEvent{}) }
-
-// TODO: embedded structures make testing difficult
-// func TestStructSysWmInfo(t *testing.T)   { testStructEq(t, SysWMInfo{}, cSysWMinfo{}) }
-// func TestStructRendererInfo(t *testing.T) {	testStructEq(t, RendererInfo{}, realcRendererInfo{})}
-
-func testStructEq(t *testing.T, a, b interface{}) {
+func testStructABI(t *testing.T, a, b interface{}) {
 	ta, tb := reflect.TypeOf(a), reflect.TypeOf(b)
 	if ta.Size() != tb.Size() {
 		t.Errorf("struct size missmatch: %s(%d) != %s(%d)",

--- a/sdl/struct_test.go
+++ b/sdl/struct_test.go
@@ -1,0 +1,74 @@
+package sdl
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestVersionSize(t *testing.T) { testStructEquality(t, Version{}, cVersion{}) }
+
+//func TestSysWmInfoSize(t *testing.T) { testStructEquality(t, SysWMInfo{}, cSysWMinfo{}) }
+// PixelFormat
+// Surface
+// WindowEvent
+
+func testStructEquality(t *testing.T, a, b interface{}) {
+	ta, tb := reflect.TypeOf(a), reflect.TypeOf(b)
+	if ta.Size() != tb.Size() {
+		t.Errorf("struct size missmatch: %s(%d) != %s(%d)",
+			ta.Name(), ta.Size(), tb.Name(), tb.Size())
+	}
+
+	dumpStructFormat(t, ta)
+	dumpStructFormat(t, tb)
+
+	for i := 0; i < ta.NumField(); i++ {
+		f := ta.Field(i)
+		if f.Name == "_" {
+			// ignore padding fields
+			continue
+		}
+		verifyField(t, f, tb)
+	}
+}
+
+func dumpStructFormat(t *testing.T, s reflect.Type) {
+	const format = "%25s%10d%10d"
+	t.Logf("%25s%10s%10s", "name", "offset", "size")
+	for i := 0; i < s.NumField(); i++ {
+		f := s.Field(i)
+		if f.Name == "_" {
+			// ignore padding fields
+			continue
+		}
+		t.Logf(format, s.Name()+"."+f.Name, f.Offset, f.Type.Size())
+	}
+}
+
+func verifyField(t *testing.T, gField reflect.StructField, cType reflect.Type) {
+	var cField = searchField(cType, gField.Name)
+	if cField == nil {
+		t.Error("field not found:", gField.Name)
+		return
+	}
+	gOffset, gSize := gField.Offset, gField.Type.Size()
+	cOffset, cSize := cField.Offset, cField.Type.Size()
+	if cOffset != gOffset || cSize != gSize {
+		t.Errorf("field offset/size missmatch %s(%d, %d) != %s(%d, %d)",
+			gField.Name, gOffset, gSize,
+			cField.Name, cOffset, cSize)
+	}
+}
+
+func searchField(t reflect.Type, gName string) *reflect.StructField {
+	for i := 0; i < t.NumField(); i++ {
+		var f = t.Field(i)
+		// convert c field_name to fieldname
+		var cName = strings.Replace(f.Name, "_", "", -1)
+		if strings.EqualFold(gName, cName) {
+			return &f
+		}
+	}
+	return nil
+}

--- a/sdl/struct_test.go
+++ b/sdl/struct_test.go
@@ -7,8 +7,9 @@ import (
 )
 
 // TODO: AudioCVT is a packed struct in C - proper conversion needs some more work
-//func TestStructAudioCVT(t *testing.T)  { testStructEquality(t, AudioCVT{}, cAudioCVT{}) }
-func TestStructAudioSpec(t *testing.T) { testStructEquality(t, AudioSpec{}, cAudioSpec{}) }
+// func TestStructAudioCVT(t *testing.T)  { testStructEquality(t, AudioCVT{}, cAudioCVT{}) }
+func TestStructAudioSpec(t *testing.T)   { testStructEquality(t, AudioSpec{}, cAudioSpec{}) }
+func TestStructDisplayMode(t *testing.T) { testStructEquality(t, DisplayMode{}, cDisplayMode{}) }
 
 func TestStructKeyDownEvent(t *testing.T) { testStructEquality(t, KeyDownEvent{}, cKeyboardEvent{}) }
 func TestStructKeyUpEvent(t *testing.T)   { testStructEquality(t, KeyUpEvent{}, cKeyboardEvent{}) }
@@ -34,8 +35,9 @@ func TestStructSurface(t *testing.T)     { testStructEquality(t, Surface{}, cSur
 func TestStructVersion(t *testing.T)     { testStructEquality(t, Version{}, cVersion{}) }
 func TestStructWindowEvent(t *testing.T) { testStructEquality(t, WindowEvent{}, cWindowEvent{}) }
 
-//TODO
-//func TestStructSysWmInfo(t *testing.T)   { testStructEquality(t, SysWMInfo{}, cSysWMinfo{}) }
+// TODO: embedded structures make testing difficult
+// func TestStructSysWmInfo(t *testing.T)   { testStructEquality(t, SysWMInfo{}, cSysWMinfo{}) }
+// func TestStructRendererInfo(t *testing.T) {	testStructEquality(t, RendererInfo{}, realcRendererInfo{})}
 
 func testStructEquality(t *testing.T, a, b interface{}) {
 	ta, tb := reflect.TypeOf(a), reflect.TypeOf(b)

--- a/sdl/struct_test.go
+++ b/sdl/struct_test.go
@@ -7,39 +7,54 @@ import (
 )
 
 // TODO: AudioCVT is a packed struct in C - proper conversion needs some more work
-// func TestStructAudioCVT(t *testing.T)  { testStructEquality(t, AudioCVT{}, cAudioCVT{}) }
-func TestStructAudioSpec(t *testing.T)   { testStructEquality(t, AudioSpec{}, cAudioSpec{}) }
-func TestStructDisplayMode(t *testing.T) { testStructEquality(t, DisplayMode{}, cDisplayMode{}) }
+// func TestStructAudioCVT(t *testing.T)  { testStructEq(t, AudioCVT{}, cAudioCVT{}) }
+func TestStructAudioSpec(t *testing.T)   { testStructEq(t, AudioSpec{}, cAudioSpec{}) }
+func TestStructDisplayMode(t *testing.T) { testStructEq(t, DisplayMode{}, cDisplayMode{}) }
 
-func TestStructKeyDownEvent(t *testing.T) { testStructEquality(t, KeyDownEvent{}, cKeyboardEvent{}) }
-func TestStructKeyUpEvent(t *testing.T)   { testStructEquality(t, KeyUpEvent{}, cKeyboardEvent{}) }
-func TestStructMouseButtonEvent(t *testing.T) {
-	testStructEquality(t, MouseButtonEvent{}, cMouseButtonEvent{})
-}
-func TestStructMouseMotionEvent(t *testing.T) {
-	testStructEquality(t, MouseMotionEvent{}, cMouseMotionEvent{})
-}
-func TestStructMouseWheelEvent(t *testing.T) {
-	testStructEquality(t, MouseWheelEvent{}, cMouseWheelEvent{})
-}
-func TestStructTextEditingEvent(t *testing.T) {
-	testStructEquality(t, TextEditingEvent{}, cTextEditingEvent{})
-}
-func TestStructTextInputEvent(t *testing.T) {
-	testStructEquality(t, TextInputEvent{}, cTextInputEvent{})
-}
+// EVENTS
 
-func TestStructPalette(t *testing.T)     { testStructEquality(t, Palette{}, cPalette{}) }
-func TestStructPixelFormat(t *testing.T) { testStructEquality(t, PixelFormat{}, cPixelFormat{}) }
-func TestStructSurface(t *testing.T)     { testStructEquality(t, Surface{}, cSurface{}) }
-func TestStructVersion(t *testing.T)     { testStructEquality(t, Version{}, cVersion{}) }
-func TestStructWindowEvent(t *testing.T) { testStructEquality(t, WindowEvent{}, cWindowEvent{}) }
+func TestStructKeyDown(t *testing.T)     { testStructEq(t, KeyDownEvent{}, cKeyboardEvent{}) }
+func TestStructKeyUp(t *testing.T)       { testStructEq(t, KeyUpEvent{}, cKeyboardEvent{}) }
+func TestStructMouseButton(t *testing.T) { testStructEq(t, MouseButtonEvent{}, cMouseButtonEvent{}) }
+func TestStructMouseMotion(t *testing.T) { testStructEq(t, MouseMotionEvent{}, cMouseMotionEvent{}) }
+func TestStructMouseWheel(t *testing.T)  { testStructEq(t, MouseWheelEvent{}, cMouseWheelEvent{}) }
+func TestStructTextEditing(t *testing.T) { testStructEq(t, TextEditingEvent{}, cTextEditingEvent{}) }
+func TestStructTextInput(t *testing.T)   { testStructEq(t, TextInputEvent{}, cTextInputEvent{}) }
+func TestStructJoyAxis(t *testing.T)     { testStructEq(t, JoyAxisEvent{}, cJoyAxisEvent{}) }
+func TestStructJoyBall(t *testing.T)     { testStructEq(t, JoyBallEvent{}, cJoyBallEvent{}) }
+func TestStructJoyHat(t *testing.T)      { testStructEq(t, JoyHatEvent{}, cJoyHatEvent{}) }
+func TestStructJoyButton(t *testing.T)   { testStructEq(t, JoyButtonEvent{}, cJoyButtonEvent{}) }
+func TestStructControllerAxis(t *testing.T) {
+	testStructEq(t, ControllerAxisEvent{}, cControllerAxisEvent{})
+}
+func TestStructControllerBtn(t *testing.T) {
+	testStructEq(t, ControllerButtonEvent{}, cControllerButtonEvent{})
+}
+func TestStructControllerDev(t *testing.T) {
+	testStructEq(t, ControllerDeviceEvent{}, cControllerDeviceEvent{})
+}
+func TestStructTouchFinger(t *testing.T)  { testStructEq(t, TouchFingerEvent{}, cTouchFingerEvent{}) }
+func TestStructMultiGesture(t *testing.T) { testStructEq(t, MultiGestureEvent{}, cMultiGestureEvent{}) }
+func TestStructDollarGesture(t *testing.T) {
+	testStructEq(t, DollarGestureEvent{}, cDollarGestureEvent{})
+}
+func TestStructDrop(t *testing.T)  { testStructEq(t, DropEvent{}, cDropEvent{}) }
+func TestStructUser(t *testing.T)  { testStructEq(t, UserEvent{}, cUserEvent{}) }
+func TestStructSysWM(t *testing.T) { testStructEq(t, SysWMEvent{}, cSysWMEvent{}) }
+
+// END OF EVENTS
+
+func TestStructPalette(t *testing.T)     { testStructEq(t, Palette{}, cPalette{}) }
+func TestStructPixelFormat(t *testing.T) { testStructEq(t, PixelFormat{}, cPixelFormat{}) }
+func TestStructSurface(t *testing.T)     { testStructEq(t, Surface{}, cSurface{}) }
+func TestStructVersion(t *testing.T)     { testStructEq(t, Version{}, cVersion{}) }
+func TestStructWindowEvent(t *testing.T) { testStructEq(t, WindowEvent{}, cWindowEvent{}) }
 
 // TODO: embedded structures make testing difficult
-// func TestStructSysWmInfo(t *testing.T)   { testStructEquality(t, SysWMInfo{}, cSysWMinfo{}) }
-// func TestStructRendererInfo(t *testing.T) {	testStructEquality(t, RendererInfo{}, realcRendererInfo{})}
+// func TestStructSysWmInfo(t *testing.T)   { testStructEq(t, SysWMInfo{}, cSysWMinfo{}) }
+// func TestStructRendererInfo(t *testing.T) {	testStructEq(t, RendererInfo{}, realcRendererInfo{})}
 
-func testStructEquality(t *testing.T, a, b interface{}) {
+func testStructEq(t *testing.T, a, b interface{}) {
 	ta, tb := reflect.TypeOf(a), reflect.TypeOf(b)
 	if ta.Size() != tb.Size() {
 		t.Errorf("struct size missmatch: %s(%d) != %s(%d)",

--- a/sdl/struct_test.go
+++ b/sdl/struct_test.go
@@ -28,6 +28,7 @@ func TestStructTextInputEvent(t *testing.T) {
 	testStructEquality(t, TextInputEvent{}, cTextInputEvent{})
 }
 
+func TestStructPalette(t *testing.T)     { testStructEquality(t, Palette{}, cPalette{}) }
 func TestStructPixelFormat(t *testing.T) { testStructEquality(t, PixelFormat{}, cPixelFormat{}) }
 func TestStructSurface(t *testing.T)     { testStructEquality(t, Surface{}, cSurface{}) }
 func TestStructVersion(t *testing.T)     { testStructEquality(t, Version{}, cVersion{}) }

--- a/sdl/struct_test.go
+++ b/sdl/struct_test.go
@@ -57,15 +57,13 @@ func testStructEquality(t *testing.T, a, b interface{}) {
 }
 
 func dumpStructFormat(t *testing.T, s reflect.Type) {
-	const format = "%25s%10d%10d"
-	t.Logf("%25s%10s%10s", "name", "offset", "size")
+	const dFormat = "%5d %30s %8d %8d"
+	var sFormat = strings.Replace(dFormat, "d", "s", -1)
+
+	t.Logf(sFormat, "index", "name", "offset", "size")
 	for i := 0; i < s.NumField(); i++ {
 		f := s.Field(i)
-		if f.Name == "_" {
-			// ignore padding fields
-			continue
-		}
-		t.Logf(format, s.Name()+"."+f.Name, f.Offset, f.Type.Size())
+		t.Logf(dFormat, i, s.Name()+"."+f.Name, f.Offset, f.Type.Size())
 	}
 }
 

--- a/sdl/struct_test.go
+++ b/sdl/struct_test.go
@@ -6,6 +6,10 @@ import (
 	"testing"
 )
 
+// TODO: AudioCVT is a packed struct in C - proper conversion needs some more work
+//func TestStructAudioCVT(t *testing.T)  { testStructEquality(t, AudioCVT{}, cAudioCVT{}) }
+func TestStructAudioSpec(t *testing.T) { testStructEquality(t, AudioSpec{}, cAudioSpec{}) }
+
 func TestStructKeyDownEvent(t *testing.T) { testStructEquality(t, KeyDownEvent{}, cKeyboardEvent{}) }
 func TestStructKeyUpEvent(t *testing.T)   { testStructEquality(t, KeyUpEvent{}, cKeyboardEvent{}) }
 func TestStructMouseButtonEvent(t *testing.T) {

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -20,15 +20,16 @@ type Surface struct {
 	Format   *PixelFormat
 	W        int32
 	H        int32
-	Pitch    int
+	Pitch    int32
 	pixels   unsafe.Pointer // use Pixels() for access
 	UserData unsafe.Pointer
-	Locked   int
+	Locked   int32
 	LockData unsafe.Pointer
 	ClipRect Rect
-	_map     *[0]byte
-	RefCount int
+	_        unsafe.Pointer // private c field 'map'
+	RefCount int32
 }
+type cSurface C.SDL_Surface
 
 type blit C.SDL_blit
 

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -31,8 +31,6 @@ type Surface struct {
 }
 type cSurface C.SDL_Surface
 
-type blit C.SDL_blit
-
 func (surface *Surface) cptr() *C.SDL_Surface {
 	return (*C.SDL_Surface)(unsafe.Pointer(surface))
 }

--- a/sdl/syswm.go
+++ b/sdl/syswm.go
@@ -28,7 +28,7 @@ const (
 	SYSWM_MIR      = C.SDL_SYSWM_MIR
 )
 
-// SysWMInfo (https://wiki.libsdl.org/SDL_SysWMInfo)
+// SysWMInfo (https://wiki.libsdl.org/SDL_SysWMinfo)
 type SysWMInfo struct {
 	Version   Version
 	Subsystem uint32

--- a/sdl/version.go
+++ b/sdl/version.go
@@ -16,6 +16,7 @@ type Version struct {
 	Minor uint8
 	Patch uint8
 }
+type cVersion C.SDL_version
 
 func (v *Version) cptr() *C.SDL_version {
 	return (*C.SDL_version)(unsafe.Pointer(v))

--- a/sdl/video.go
+++ b/sdl/video.go
@@ -92,6 +92,7 @@ type DisplayMode struct {
 	RefreshRate int32
 	DriverData  unsafe.Pointer
 }
+type cDisplayMode C.SDL_DisplayMode
 
 type Window C.SDL_Window
 type GLContext C.SDL_GLContext


### PR DESCRIPTION
The main point of this pull request is to verify the layout of
structures. In Issue #86 the alignment of "RendererInfoData" and
"DisplayMode" was fixed.

Commit b5350016 of this PR adds the test infrastructure
find such misalignment structures.

11027bc Tests and fixes the structure PixelFormat
4e21bee Tests and fixes the structure Surface
6c7267c Tests some of the structures in events.go (all good)
d080b6f Tests and fixes the structure AudioSpec
97d7db6 Tests and fixes the structure Palette
c96b82c Tests the already fixed DisplayMode
5173707 Tests the remaining structures of events.go (all good)
a970360 Clean-up/readability of the tests

Other minor cleanups:
1f13790: Fixes the documentation URL for SDL_SysWMinfo
0d7dea8: Fixes the CloseAudio function which used to call SDL_UnlockAudio instead of SDL_CloseAudio.
62f04aa: Rmoves the unused (and unexported) type 'blit'