### PR TITLE
sdl/surface.go: idiomatic errors

### DIFF
--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -121,8 +121,11 @@ func (surface *Surface) SetRLE(flag int) error {
 }
 
 // Surface (https://wiki.libsdl.org/SDL_SetColorKey)
-func (surface *Surface) SetColorKey(flag int, key uint32) int {
-	return int(C.SDL_SetColorKey(surface.cptr(), C.int(flag), C.Uint32(key)))
+func (surface *Surface) SetColorKey(flag int, key uint32) error {
+	if C.SDL_SetColorKey(surface.cptr(), C.int(flag), C.Uint32(key)) != 0 {
+		return GetError()
+	}
+	return nil
 }
 
 // Surface (https://wiki.libsdl.org/SDL_GetColorKey)

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -71,8 +71,11 @@ func (surface *Surface) Free() {
 }
 
 // Surface (https://wiki.libsdl.org/SDL_SetSurfacePalette)
-func (surface *Surface) SetPalette(palette *Palette) int {
-	return int(C.SDL_SetSurfacePalette(surface.cptr(), palette.cptr()))
+func (surface *Surface) SetPalette(palette *Palette) error {
+	if C.SDL_SetSurfacePalette(surface.cptr(), palette.cptr()) != 0 {
+		return GetError()
+	}
+	return nil
 }
 
 // Surface (https://wiki.libsdl.org/SDL_LockSurface)

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -212,8 +212,11 @@ func (surface *Surface) ConvertFormat(pixelFormat uint32, flags uint32) *Surface
 
 // ConvertPixels (https://wiki.libsdl.org/SDL_ConvertPixels)
 func ConvertPixels(width, height int, srcFormat uint32, src unsafe.Pointer, srcPitch int,
-	dstFormat uint32, dst unsafe.Pointer, dstPitch int) int {
-	return int(C.SDL_ConvertPixels(C.int(width), C.int(height), C.Uint32(srcFormat), src, C.int(srcPitch), C.Uint32(dstFormat), dst, C.int(dstPitch)))
+	dstFormat uint32, dst unsafe.Pointer, dstPitch int) error {
+	if C.SDL_ConvertPixels(C.int(width), C.int(height), C.Uint32(srcFormat), src, C.int(srcPitch), C.Uint32(dstFormat), dst, C.int(dstPitch)) != 0 {
+		return GetError()
+	}
+	return nil
 }
 
 // Surface (https://wiki.libsdl.org/SDL_FillRect)

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -146,12 +146,14 @@ func (surface *Surface) SetColorMod(r, g, b uint8) error {
 }
 
 // Surface (https://wiki.libsdl.org/SDL_GetSurfaceColorMod)
-func (surface *Surface) GetColorMod() (r, g, b uint8, status int) {
+func (surface *Surface) GetColorMod() (r, g, b uint8, err error) {
 	_r := (*C.Uint8)(unsafe.Pointer(&r))
 	_g := (*C.Uint8)(unsafe.Pointer(&g))
 	_b := (*C.Uint8)(unsafe.Pointer(&b))
-	status = int(C.SDL_GetSurfaceColorMod(surface.cptr(), _r, _g, _b))
-	return r, g, b, status
+	if C.SDL_GetSurfaceColorMod(surface.cptr(), _r, _g, _b) != 0 {
+		return r, g, b, GetError()
+	}
+	return r, g, b, nil
 }
 
 // Surface (https://wiki.libsdl.org/SDL_SetSurfaceAlphaMod)

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -113,8 +113,11 @@ func (surface *Surface) SaveBMP(file string) error {
 }
 
 // Surface (https://wiki.libsdl.org/SDL_SetSurfaceRLE)
-func (surface *Surface) SetRLE(flag int) int {
-	return int(C.SDL_SetSurfaceRLE(surface.cptr(), C.int(flag)))
+func (surface *Surface) SetRLE(flag int) error {
+	if C.SDL_SetSurfaceRLE(surface.cptr(), C.int(flag)) != 0 {
+		return GetError()
+	}
+	return nil
 }
 
 // Surface (https://wiki.libsdl.org/SDL_SetColorKey)

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -268,8 +268,11 @@ func (src *Surface) LowerBlit(srcRect *Rect, dst *Surface, dstRect *Rect) error 
 }
 
 // Surface (https://wiki.libsdl.org/SDL_SoftStretch)
-func (src *Surface) SoftStretch(srcRect *Rect, dst *Surface, dstRect *Rect) int {
-	return int(C.SDL_SoftStretch(src.cptr(), srcRect.cptr(), dst.cptr(), dstRect.cptr()))
+func (src *Surface) SoftStretch(srcRect *Rect, dst *Surface, dstRect *Rect) error {
+	if C.SDL_SoftStretch(src.cptr(), srcRect.cptr(), dst.cptr(), dstRect.cptr()) != 0 {
+		return GetError()
+	}
+	return nil
 }
 
 // Surface (https://wiki.libsdl.org/SDL_UpperBlitScaled)

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -252,8 +252,11 @@ func (src *Surface) BlitScaled(srcRect *Rect, dst *Surface, dstRect *Rect) error
 }
 
 // Surface (https://wiki.libsdl.org/SDL_UpperBlit)
-func (src *Surface) UpperBlit(srcRect *Rect, dst *Surface, dstRect *Rect) int {
-	return int(C.SDL_UpperBlit(src.cptr(), srcRect.cptr(), dst.cptr(), dstRect.cptr()))
+func (src *Surface) UpperBlit(srcRect *Rect, dst *Surface, dstRect *Rect) error {
+	if C.SDL_UpperBlit(src.cptr(), srcRect.cptr(), dst.cptr(), dstRect.cptr()) != 0 {
+		return GetError()
+	}
+	return nil
 }
 
 // Surface (https://wiki.libsdl.org/SDL_LowerBlit)

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -260,8 +260,11 @@ func (src *Surface) UpperBlit(srcRect *Rect, dst *Surface, dstRect *Rect) error 
 }
 
 // Surface (https://wiki.libsdl.org/SDL_LowerBlit)
-func (src *Surface) LowerBlit(srcRect *Rect, dst *Surface, dstRect *Rect) int {
-	return int(C.SDL_LowerBlit(src.cptr(), srcRect.cptr(), dst.cptr(), dstRect.cptr()))
+func (src *Surface) LowerBlit(srcRect *Rect, dst *Surface, dstRect *Rect) error {
+	if C.SDL_LowerBlit(src.cptr(), srcRect.cptr(), dst.cptr(), dstRect.cptr()) != 0 {
+		return GetError()
+	}
+	return nil
 }
 
 // Surface (https://wiki.libsdl.org/SDL_SoftStretch)

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -174,8 +174,11 @@ func (surface *Surface) GetAlphaMod() (alpha uint8, err error) {
 }
 
 // Surface (https://wiki.libsdl.org/SDL_SetSurfaceBlendMode)
-func (surface *Surface) SetBlendMode(bm BlendMode) int {
-	return int(C.SDL_SetSurfaceBlendMode(surface.cptr(), bm.c()))
+func (surface *Surface) SetBlendMode(bm BlendMode) error {
+	if C.SDL_SetSurfaceBlendMode(surface.cptr(), bm.c()) != 0 {
+		return GetError()
+	}
+	return nil
 }
 
 // Surface (https://wiki.libsdl.org/SDL_GetSurfaceBlendMode)

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -244,8 +244,11 @@ func (src *Surface) Blit(srcRect *Rect, dst *Surface, dstRect *Rect) error {
 }
 
 // Surface (https://wiki.libsdl.org/SDL_BlitScaled)
-func (src *Surface) BlitScaled(srcRect *Rect, dst *Surface, dstRect *Rect) int {
-	return int(C.SDL_BlitScaled(src.cptr(), srcRect.cptr(), dst.cptr(), dstRect.cptr()))
+func (src *Surface) BlitScaled(srcRect *Rect, dst *Surface, dstRect *Rect) error {
+	if C.SDL_BlitScaled(src.cptr(), srcRect.cptr(), dst.cptr(), dstRect.cptr()) != 0 {
+		return GetError()
+	}
+	return nil
 }
 
 // Surface (https://wiki.libsdl.org/SDL_UpperBlit)

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -284,8 +284,11 @@ func (src *Surface) UpperBlitScaled(srcRect *Rect, dst *Surface, dstRect *Rect) 
 }
 
 // Surface (https://wiki.libsdl.org/SDL_LowerBlitScaled)
-func (src *Surface) LowerBlitScaled(srcRect *Rect, dst *Surface, dstRect *Rect) int {
-	return int(C.SDL_LowerBlitScaled(src.cptr(), srcRect.cptr(), dst.cptr(), dstRect.cptr()))
+func (src *Surface) LowerBlitScaled(srcRect *Rect, dst *Surface, dstRect *Rect) error {
+	if C.SDL_LowerBlitScaled(src.cptr(), srcRect.cptr(), dst.cptr(), dstRect.cptr()) != 0 {
+		return GetError()
+	}
+	return nil
 }
 
 func (surface *Surface) PixelNum() int {

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -276,8 +276,11 @@ func (src *Surface) SoftStretch(srcRect *Rect, dst *Surface, dstRect *Rect) erro
 }
 
 // Surface (https://wiki.libsdl.org/SDL_UpperBlitScaled)
-func (src *Surface) UpperBlitScaled(srcRect *Rect, dst *Surface, dstRect *Rect) int {
-	return int(C.SDL_UpperBlitScaled(src.cptr(), srcRect.cptr(), dst.cptr(), dstRect.cptr()))
+func (src *Surface) UpperBlitScaled(srcRect *Rect, dst *Surface, dstRect *Rect) error {
+	if C.SDL_UpperBlitScaled(src.cptr(), srcRect.cptr(), dst.cptr(), dstRect.cptr()) != 0 {
+		return GetError()
+	}
+	return nil
 }
 
 // Surface (https://wiki.libsdl.org/SDL_LowerBlitScaled)

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -129,10 +129,12 @@ func (surface *Surface) SetColorKey(flag int, key uint32) error {
 }
 
 // Surface (https://wiki.libsdl.org/SDL_GetColorKey)
-func (surface *Surface) GetColorKey() (key uint32, status int) {
+func (surface *Surface) GetColorKey() (key uint32, err error) {
 	_key := (*C.Uint32)(unsafe.Pointer(&key))
-	status = int(C.SDL_GetColorKey(surface.cptr(), _key))
-	return key, status
+	if C.SDL_GetColorKey(surface.cptr(), _key) != 0 {
+		return key, GetError()
+	}
+	return key, nil
 }
 
 // Surface (https://wiki.libsdl.org/SDL_SetSurfaceColorMod)

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -157,8 +157,11 @@ func (surface *Surface) GetColorMod() (r, g, b uint8, err error) {
 }
 
 // Surface (https://wiki.libsdl.org/SDL_SetSurfaceAlphaMod)
-func (surface *Surface) SetAlphaMod(alpha uint8) int {
-	return int(C.SDL_SetSurfaceAlphaMod(surface.cptr(), C.Uint8(alpha)))
+func (surface *Surface) SetAlphaMod(alpha uint8) error {
+	if C.SDL_SetSurfaceAlphaMod(surface.cptr(), C.Uint8(alpha)) != 0 {
+		return GetError()
+	}
+	return nil
 }
 
 // Surface (https://wiki.libsdl.org/SDL_GetSurfaceAlphaMod)

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -165,10 +165,12 @@ func (surface *Surface) SetAlphaMod(alpha uint8) error {
 }
 
 // Surface (https://wiki.libsdl.org/SDL_GetSurfaceAlphaMod)
-func (surface *Surface) GetAlphaMod() (alpha uint8, status int) {
+func (surface *Surface) GetAlphaMod() (alpha uint8, err error) {
 	_alpha := (*C.Uint8)(unsafe.Pointer(&alpha))
-	status = int(C.SDL_GetSurfaceAlphaMod(surface.cptr(), _alpha))
-	return alpha, status
+	if C.SDL_GetSurfaceAlphaMod(surface.cptr(), _alpha) != 0 {
+		return alpha, GetError()
+	}
+	return alpha, nil
 }
 
 // Surface (https://wiki.libsdl.org/SDL_SetSurfaceBlendMode)

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -182,9 +182,11 @@ func (surface *Surface) SetBlendMode(bm BlendMode) error {
 }
 
 // Surface (https://wiki.libsdl.org/SDL_GetSurfaceBlendMode)
-func (surface *Surface) GetBlendMode() (bm BlendMode, status int) {
-	status = int(C.SDL_GetSurfaceBlendMode(surface.cptr(), bm.cptr()))
-	return bm, status
+func (surface *Surface) GetBlendMode() (bm BlendMode, err error) {
+	if C.SDL_GetSurfaceBlendMode(surface.cptr(), bm.cptr()) != 0 {
+		return bm, GetError()
+	}
+	return bm, nil
 }
 
 // Surface (https://wiki.libsdl.org/SDL_SetClipRect)

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -100,13 +100,16 @@ func LoadBMP(file string) *Surface {
 }
 
 // Surface (https://wiki.libsdl.org/SDL_SaveBMP_RW)
-func (surface *Surface) SaveBMP_RW(dst *RWops, freeDst int) int {
-	return int(C.SDL_SaveBMP_RW(surface.cptr(), dst.cptr(), C.int(freeDst)))
+func (surface *Surface) SaveBMP_RW(dst *RWops, freeDst int) error {
+	if C.SDL_SaveBMP_RW(surface.cptr(), dst.cptr(), C.int(freeDst)) != 0 {
+		return GetError()
+	}
+	return nil
 }
 
 // Surface (https://wiki.libsdl.org/SDL_SaveBMP)
-func (surface *Surface) SaveBMP(file string) int {
-	return int(surface.SaveBMP_RW(RWFromFile(file, "wb"), 1))
+func (surface *Surface) SaveBMP(file string) error {
+	return surface.SaveBMP_RW(RWFromFile(file, "wb"), 1)
 }
 
 // Surface (https://wiki.libsdl.org/SDL_SetSurfaceRLE)

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -236,8 +236,11 @@ func (surface *Surface) FillRects(rects []Rect, color uint32) error {
 }
 
 // Surface (https://wiki.libsdl.org/SDL_BlitSurface)
-func (src *Surface) Blit(srcRect *Rect, dst *Surface, dstRect *Rect) int {
-	return int(C.SDL_BlitSurface(src.cptr(), srcRect.cptr(), dst.cptr(), dstRect.cptr()))
+func (src *Surface) Blit(srcRect *Rect, dst *Surface, dstRect *Rect) error {
+	if C.SDL_BlitSurface(src.cptr(), srcRect.cptr(), dst.cptr(), dstRect.cptr()) != 0 {
+		return GetError()
+	}
+	return nil
 }
 
 // Surface (https://wiki.libsdl.org/SDL_BlitScaled)

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -138,8 +138,11 @@ func (surface *Surface) GetColorKey() (key uint32, err error) {
 }
 
 // Surface (https://wiki.libsdl.org/SDL_SetSurfaceColorMod)
-func (surface *Surface) SetColorMod(r, g, b uint8) int {
-	return int(C.SDL_SetSurfaceColorMod(surface.cptr(), C.Uint8(r), C.Uint8(g), C.Uint8(b)))
+func (surface *Surface) SetColorMod(r, g, b uint8) error {
+	if C.SDL_SetSurfaceColorMod(surface.cptr(), C.Uint8(r), C.Uint8(g), C.Uint8(b)) != 0 {
+		return GetError()
+	}
+	return nil
 }
 
 // Surface (https://wiki.libsdl.org/SDL_GetSurfaceColorMod)


### PR DESCRIPTION
This takes care of all the functions in surface.go that were returning integer error codes.