### PR TITLE
display utf8 string

### DIFF
--- a/sdl_ttf/sdl_ttf.go
+++ b/sdl_ttf/sdl_ttf.go
@@ -118,6 +118,29 @@ func (f *Font) RenderText_Blended(text string, color sdl.Color) *sdl.Surface {
 	return surface
 }
 
+func (f *Font) RenderUTF8_Solid(text string, color sdl.Color) *sdl.Surface {
+	_text := C.CString(text)
+	defer C.free(unsafe.Pointer(_text))
+	_c := C.SDL_Color{C.Uint8(color.R), C.Uint8(color.G), C.Uint8(color.B), C.Uint8(color.A)}
+	surface := (*sdl.Surface)(unsafe.Pointer(C.TTF_RenderUTF8_Solid(f.f, _text, _c)))
+	return surface
+}
+func (f *Font) RenderUTF8_Shaded(text string, fg, bg sdl.Color) *sdl.Surface {
+	_text := C.CString(text)
+	defer C.free(unsafe.Pointer(_text))
+	_fg := C.SDL_Color{C.Uint8(fg.R), C.Uint8(fg.G), C.Uint8(fg.B), C.Uint8(fg.A)}
+	_bg := C.SDL_Color{C.Uint8(bg.R), C.Uint8(bg.G), C.Uint8(bg.B), C.Uint8(bg.A)}
+	surface := (*sdl.Surface)(unsafe.Pointer(C.TTF_RenderUTF8_Shaded(f.f, _text, _fg, _bg)))
+	return surface
+}
+func (f *Font) RenderUTF8_Blended(text string, color sdl.Color) *sdl.Surface {
+	_text := C.CString(text)
+	defer C.free(unsafe.Pointer(_text))
+	_c := C.SDL_Color{C.Uint8(color.R), C.Uint8(color.G), C.Uint8(color.B), C.Uint8(color.A)}
+	surface := (*sdl.Surface)(unsafe.Pointer(C.TTF_RenderUTF8_Blended(f.f, _text, _c)))
+	return surface
+}
+
 func (f *Font) Close() {
 	C.TTF_CloseFont(f.f)
 	f.f = nil


### PR DESCRIPTION
add utf8 support to sdl_ttf
need unicode font to display utf8 text
see 
https://github.com/kasworld/go-sdlgui/tree/master/example

tested linux mint 17.1 
( not tested in ms windows  )