### PR TITLE
Update README.md to show windows install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ On __Arch Linux__, type:
 On __Mac OS X__, install SDL2 via [Homebrew](http://brew.sh) like so:
 `brew install sdl2{,_image,_ttf,_mixer}`
 
+On __Windows__, install SDL2 via [Msys2](https://msys2.github.io) type:
+`pacman -S mingw-w64-x86_64-SDL2{,_mixer,_image,_ttf}`
 
 Installation
 ============

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ On __Arch Linux__, type:
 On __Mac OS X__, install SDL2 via [Homebrew](http://brew.sh) like so:
 `brew install sdl2{,_image,_ttf,_mixer}`
 
-On __Windows__, install SDL2 via [Msys2](https://msys2.github.io) type:
+On __Windows__, install SDL2 via [Msys2](https://msys2.github.io) like so:
 `pacman -S mingw-w64-x86_64-SDL2{,_mixer,_image,_ttf}`
 
 Installation

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ On __Mac OS X__, install SDL2 via [Homebrew](http://brew.sh) like so:
 `brew install sdl2{,_image,_ttf,_mixer}`
 
 On __Windows__, install SDL2 via [Msys2](https://msys2.github.io) like so:
-`pacman -S mingw-w64-x86_64-SDL2{,_mixer,_image,_ttf}`
+`pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-SDL2{,_mixer,_image,_ttf}`
 
 Installation
 ============


### PR DESCRIPTION
The instructions added to the README.md allow go-sdl2 to be "go gettable" when called by running the `mingw64_shell.bat`

Using msys2 mingw64 packages is by far the easiest way I've found to get pretty much any cgo stuff to compile in Windows.