### PR TITLE
Return error on ttf.Init() instead of int

### DIFF
--- a/sdl_ttf/sdl_ttf.go
+++ b/sdl_ttf/sdl_ttf.go
@@ -34,8 +34,11 @@ type Font struct {
 	f *C.TTF_Font
 }
 
-func Init() int {
-	return int(C.TTF_Init())
+func Init() error {
+	if C.TTF_Init() == -1 {
+		return GetError()
+	}
+	return nil
 }
 
 func WasInit() bool {


### PR DESCRIPTION
It's a breaking change, but I think we can all agree that returning an `error` instead of an `int` is the right thing to do here.