### PR TITLE
Add audio example

### DIFF
--- a/examples/audio.go
+++ b/examples/audio.go
@@ -1,0 +1,47 @@
+package main
+
+// typedef unsigned char Uint8;
+// void SineWave(void *userdata, Uint8 *stream, int len);
+import "C"
+import (
+	"math"
+	"reflect"
+	"time"
+	"unsafe"
+
+	"github.com/veandco/go-sdl2/sdl"
+)
+
+const (
+	toneHz   = 440
+	sampleHz = 48000
+	dPhase   = 2 * math.Pi * toneHz / sampleHz
+)
+
+//export SineWave
+func SineWave(userdata unsafe.Pointer, stream *C.Uint8, length C.int) {
+	n := int(length)
+	hdr := reflect.SliceHeader{Data: uintptr(unsafe.Pointer(stream)), Len: n, Cap: n}
+	buf := *(*[]C.Uint8)(unsafe.Pointer(&hdr))
+
+	var phase float64
+	for i := 0; i < n; i += 2 {
+		phase += dPhase
+		sample := C.Uint8((math.Sin(phase) + 0.999999) * 128)
+		buf[i] = sample
+		buf[i+1] = sample
+	}
+}
+
+func main() {
+	spec := &sdl.AudioSpec{
+		Freq:     sampleHz,
+		Format:   sdl.AUDIO_U8,
+		Channels: 2,
+		Samples:  sampleHz,
+		Callback: sdl.AudioCallback(C.SineWave),
+	}
+	sdl.OpenAudio(spec, nil)
+	sdl.PauseAudio(0)
+	time.Sleep(1 * time.Second)
+}


### PR DESCRIPTION
Demonstrates usage of `sdl.AudioSpec` and `sdl.AudioCallback` to generate a sine wave tone.

Re: #127 