### PR TITLE
Explicitly convert int to int32 in IntersectLine

### DIFF
--- a/sdl/rect.go
+++ b/sdl/rect.go
@@ -64,11 +64,21 @@ func EnclosePoints(points []Point, clip *Rect) (result Rect, ok bool) {
 	return
 }
 
-// IntersectLine
+// IntersectLine (https://wiki.libsdl.org/SDL_IntersectRectAndLine)
 func (rect *Rect) IntersectLine(X1, Y1, X2, Y2 *int) bool {
-	_X1 := (*C.int)(unsafe.Pointer(X1))
-	_Y1 := (*C.int)(unsafe.Pointer(Y1))
-	_X2 := (*C.int)(unsafe.Pointer(X2))
-	_Y2 := (*C.int)(unsafe.Pointer(Y2))
-	return C.SDL_IntersectRectAndLine(rect.cptr(), _X1, _Y1, _X2, _Y2) > 0
+	X1_32, Y1_32, X2_32, Y2_32 := int32(*X1), int32(*Y1), int32(*X2), int32(*Y2)
+
+	_X1 := (*C.int)(unsafe.Pointer(&X1_32))
+	_Y1 := (*C.int)(unsafe.Pointer(&Y1_32))
+	_X2 := (*C.int)(unsafe.Pointer(&X2_32))
+	_Y2 := (*C.int)(unsafe.Pointer(&Y2_32))
+
+	result := C.SDL_IntersectRectAndLine(rect.cptr(), _X1, _Y1, _X2, _Y2) == C.SDL_TRUE
+
+	*X1 = int(X1_32)
+	*Y1 = int(Y1_32)
+	*X2 = int(X2_32)
+	*Y2 = int(Y2_32)
+
+	return result
 }

--- a/sdl/rect.go
+++ b/sdl/rect.go
@@ -65,7 +65,7 @@ func EnclosePoints(points []Point, clip *Rect) (result Rect, ok bool) {
 }
 
 // IntersectLine (https://wiki.libsdl.org/SDL_IntersectRectAndLine)
-func (rect *Rect) IntersectLine(X1, Y1, X2, Y2 *int) bool {
+func (r *Rect) IntersectLine(X1, Y1, X2, Y2 *int) bool {
 	X1_32, Y1_32, X2_32, Y2_32 := int32(*X1), int32(*Y1), int32(*X2), int32(*Y2)
 
 	_X1 := (*C.int)(unsafe.Pointer(&X1_32))

--- a/sdl/rect.go
+++ b/sdl/rect.go
@@ -73,7 +73,7 @@ func (r *Rect) IntersectLine(X1, Y1, X2, Y2 *int) bool {
 	_X2 := (*C.int)(unsafe.Pointer(&X2_32))
 	_Y2 := (*C.int)(unsafe.Pointer(&Y2_32))
 
-	result := C.SDL_IntersectRectAndLine(rect.cptr(), _X1, _Y1, _X2, _Y2) == C.SDL_TRUE
+	result := C.SDL_IntersectRectAndLine(r.cptr(), _X1, _Y1, _X2, _Y2) == C.SDL_TRUE
 
 	*X1 = int(X1_32)
 	*Y1 = int(Y1_32)

--- a/sdl/rect_test.go
+++ b/sdl/rect_test.go
@@ -22,3 +22,34 @@ func TestRectEmpty(t *testing.T) {
 		}
 	}
 }
+
+func TestIntersectLines(t *testing.T) {
+
+	var tests = []struct {
+		want bool
+		in   struct{ x1, y1, x2, y2 int }
+		out  struct{ x1, y1, x2, y2 int }
+		r    *Rect
+	}{
+		{want: false,
+			in:  struct{ x1, y1, x2, y2 int }{15, 15, 25, 25},
+			out: struct{ x1, y1, x2, y2 int }{15, 15, 25, 25},
+			r:   &Rect{X: 0, Y: 0, W: 10, H: 10}},
+		{want: true,
+			in:  struct{ x1, y1, x2, y2 int }{-1, -1, 11, 11},
+			out: struct{ x1, y1, x2, y2 int }{0, 0, 9, 9},
+			r:   &Rect{X: 0, Y: 0, W: 10, H: 10}}}
+
+	for _, test := range tests {
+		original := test.in
+		if result := test.r.IntersectLine(&test.in.x1, &test.in.y1, &test.in.x2, &test.in.y2); result != test.want {
+			t.Errorf("%v.IntersectLines(%v, %v, %v, %v) = %v - want %v",
+				test.r, original.x1, original.y1, original.x2, original.y2, result, test.want)
+		}
+
+		if test.in != test.out {
+			t.Errorf("%v.IntersectLines(%v, %v, %v, %v) gives %v - want %v",
+				test.r, original.x1, original.y1, original.x2, original.y2, test.in, test.out)
+		}
+	}
+}


### PR DESCRIPTION
As discussed on #131, the current version of IntersectLine directly makes a *C.int out of a Go *int. On 64-bit machines, Go ints are 64-bits in size, whereas C ints are generally still 32-bit. This isn't an issue on little endian machines, but big endian targets will have trouble.

A test has also been added.