### PR TITLE
Go implementation of the rect tools

### DIFF
--- a/sdl/rect.go
+++ b/sdl/rect.go
@@ -4,13 +4,16 @@ package sdl
 import "C"
 import "unsafe"
 
-// Point (https://wiki.libsdl.org/SDL_Point)
+// Point is a structure that defines a two demensional point.
+// (https://wiki.libsdl.org/SDL_Point)
 type Point struct {
 	X int32
 	Y int32
 }
 
-// Rect (https://wiki.libsdl.org/SDL_Rect)
+// Rect is a structure that defines a rectangle, with the origin at the upper
+// left.
+// (https://wiki.libsdl.org/SDL_Rect)
 type Rect struct {
 	X int32
 	Y int32
@@ -22,16 +25,18 @@ func (p *Point) cptr() *C.SDL_Point {
 	return (*C.SDL_Point)(unsafe.Pointer(p))
 }
 
-func (r *Rect) cptr() *C.SDL_Rect {
-	return (*C.SDL_Rect)(unsafe.Pointer(r))
+func (a *Rect) cptr() *C.SDL_Rect {
+	return (*C.SDL_Rect)(unsafe.Pointer(a))
 }
 
-// Rect (https://wiki.libsdl.org/SDL_RectEmpty)
-func (r *Rect) Empty() bool {
-	return r == nil || r.W <= 0 || r.H <= 0
+// Empty checks whether a rectangle has no area.
+// (https://wiki.libsdl.org/SDL_RectEmpty)
+func (a *Rect) Empty() bool {
+	return a == nil || a.W <= 0 || a.H <= 0
 }
 
-// Rect (https://wiki.libsdl.org/SDL_RectEquals)
+// Equals checks whether two rectangles are equal.
+// (https://wiki.libsdl.org/SDL_RectEquals)
 func (a *Rect) Equals(b *Rect) bool {
 	if (a != nil) && (b != nil) &&
 		(a.X == b.X) && (a.Y == a.Y) &&
@@ -41,34 +46,335 @@ func (a *Rect) Equals(b *Rect) bool {
 	return false
 }
 
-// Rect (https://wiki.libsdl.org/SDL_HasIntersection)
+// HasIntersection determines whether two rectangles intersect.
+// (https://wiki.libsdl.org/SDL_HasIntersection)
 func (a *Rect) HasIntersection(b *Rect) bool {
-	return C.SDL_HasIntersection(a.cptr(), b.cptr()) > 0
+	if a == nil || b == nil {
+		return false
+	}
+
+	// Special case for empty rects
+	if a.Empty() || b.Empty() {
+		return false
+	}
+
+	if a.X >= b.X+b.W || a.X+a.W <= b.X || a.Y >= b.Y+b.H || a.Y+a.H <= b.Y {
+		return false
+	}
+
+	return true
 }
 
-// Rect (https://wiki.libsdl.org/SDL_IntersectRect)
-func (a *Rect) Intersect(b *Rect) (result Rect, ok bool) {
-	ok = C.SDL_IntersectRect(a.cptr(), b.cptr(), result.cptr()) > 0
-	return
+// Intersect calculates the intersection of two rectangles.
+// (https://wiki.libsdl.org/SDL_IntersectRect)
+func (a *Rect) Intersect(b *Rect) (Rect, bool) {
+	var result Rect
+
+	if a == nil || b == nil {
+		return result, false
+	}
+
+	// Special case for empty rects
+	if a.Empty() || b.Empty() {
+		result.W = 0
+		result.H = 0
+		return result, false
+	}
+
+	aMin := a.X
+	aMax := aMin + a.W
+	bMin := b.X
+	bMax := bMin + b.W
+	if bMin > aMin {
+		aMin = bMin
+	}
+	result.X = aMin
+	if bMax < aMax {
+		aMax = bMax
+	}
+	result.W = aMax - aMin
+
+	aMin = a.Y
+	aMax = aMin + a.H
+	bMin = b.Y
+	bMax = bMin + b.H
+	if bMin > aMin {
+		aMin = bMin
+	}
+	result.Y = aMin
+	if bMax < aMax {
+		aMax = bMax
+	}
+	result.H = aMax - aMin
+
+	return result, !result.Empty()
 }
 
-// Rect (https://wiki.libsdl.org/SDL_UnionRect)
-func (a *Rect) Union(b *Rect) (result Rect) {
-	C.SDL_UnionRect(a.cptr(), b.cptr(), result.cptr())
-	return
+// Union calculates the union of two rectangles.
+// (https://wiki.libsdl.org/SDL_UnionRect)
+func (a *Rect) Union(b *Rect) Rect {
+	var result Rect
+
+	if a == nil || b == nil {
+		return result
+	}
+
+	// Special case for empty rects
+	if a.Empty() {
+		return *b
+	} else if b.Empty() {
+		return *a
+	} else if a.Empty() && b.Empty() {
+		return result
+	}
+
+	aMin := a.X
+	aMax := aMin + a.W
+	bMin := b.X
+	bMax := bMin + b.W
+	if bMin < aMin {
+		aMin = bMin
+	}
+	result.X = aMin
+	if bMax > aMax {
+		aMax = bMax
+	}
+	result.W = aMax - aMin
+
+	aMin = a.Y
+	aMax = aMin + a.H
+	bMin = b.Y
+	bMax = bMin + b.H
+	if bMin < aMin {
+		aMin = bMin
+	}
+	result.Y = aMin
+	if bMax > aMax {
+		aMax = bMax
+	}
+	result.H = aMax - aMin
+
+	return result
 }
 
-// EnclosePoints (https://wiki.libsdl.org/SDL_EnclosePoints)
-func EnclosePoints(points []Point, clip *Rect) (result Rect, ok bool) {
-	ok = C.SDL_EnclosePoints(points[0].cptr(), C.int(len(points)), clip.cptr(), result.cptr()) > 0
-	return
+// EnclosePoints calculates a minimal rectangle that encloses a set of points.
+// (https://wiki.libsdl.org/SDL_EnclosePoints)
+func EnclosePoints(points []Point, clip *Rect) (Rect, bool) {
+	var result Rect
+
+	if len(points) == 0 {
+		return result, false
+	}
+
+	var minX, minY, maxX, maxY int32
+	if clip != nil {
+		added := false
+		clipMinX := clip.X
+		clipMinY := clip.Y
+		clipMaxX := clip.X + clip.W - 1
+		clipMaxY := clip.Y + clip.H - 1
+
+		// If the clip has no size, we're done
+		if clip.Empty() {
+			return result, false
+		}
+
+		for _, val := range points {
+			// Check if the point is inside the clip rect
+			if val.X < clipMinX || val.X > clipMaxX || val.Y < clipMinY || val.Y > clipMaxY {
+				continue
+			}
+
+			if !added {
+				// If it's the first point
+				minX = val.X
+				maxX = val.X
+				minY = val.Y
+				maxY = val.Y
+				added = true
+			}
+
+			// Find mins and maxes
+			if val.X < minX {
+				minX = val.X
+			} else if val.X > maxX {
+				maxX = val.X
+			}
+			if val.Y < minY {
+				minY = val.Y
+			} else if val.Y > maxY {
+				maxY = val.Y
+			}
+		}
+	} else {
+		for i, val := range points {
+			if i == 0 {
+				// Populate the first point
+				minX = val.X
+				maxX = val.X
+				minY = val.Y
+				maxY = val.Y
+				continue
+			}
+
+			// Find mins and maxes
+			if val.X < minX {
+				minX = val.X
+			} else if val.X > maxX {
+				maxX = val.X
+			}
+			if val.Y < minY {
+				minY = val.Y
+			} else if val.Y > maxY {
+				maxY = val.Y
+			}
+		}
+	}
+
+	result.X = minX
+	result.Y = minY
+	result.W = (maxX - minX) + 1
+	result.H = (maxY - minY) + 1
+
+	return result, true
 }
 
-// IntersectLine
-func (rect *Rect) IntersectLine(X1, Y1, X2, Y2 *int) bool {
-	_X1 := (*C.int)(unsafe.Pointer(X1))
-	_Y1 := (*C.int)(unsafe.Pointer(Y1))
-	_X2 := (*C.int)(unsafe.Pointer(X2))
-	_Y2 := (*C.int)(unsafe.Pointer(Y2))
-	return C.SDL_IntersectRectAndLine(rect.cptr(), _X1, _Y1, _X2, _Y2) > 0
+const (
+	codeBottom = 1
+	codeTop    = 2
+	codeLeft   = 4
+	codeRight  = 8
+)
+
+func computeOutCode(rect *Rect, x, y int32) int {
+	code := 0
+	if y < rect.Y {
+		code |= codeTop
+	} else if y >= rect.Y+rect.H {
+		code |= codeBottom
+	}
+	if x < rect.X {
+		code |= codeLeft
+	} else if x >= rect.X+rect.W {
+		code |= codeRight
+	}
+
+	return code
+}
+
+// IntersectLine calculates the intersection of a rectangle and a line segment.
+// (https://wiki.libsdl.org/SDL_IntersectRectAndLine)
+func (a *Rect) IntersectLine(X1, Y1, X2, Y2 *int) bool {
+	if a.Empty() {
+		return false
+	}
+
+	x1 := int32(*X1)
+	y1 := int32(*Y1)
+	x2 := int32(*X2)
+	y2 := int32(*Y2)
+	rectX1 := a.X
+	rectY1 := a.Y
+	rectX2 := a.X + a.W - 1
+	rectY2 := a.Y + a.H - 1
+
+	// Check if the line is entirely inside the rect
+	if x1 >= rectX1 && x1 <= rectX2 && x2 >= rectX1 && x2 <= rectX2 &&
+		y1 >= rectY1 && y1 <= rectY2 && y2 >= rectY1 && y2 <= rectY2 {
+		return true
+	}
+
+	// Check if the line is entirely outside the rect
+	if (x1 < rectX1 && x2 < rectX1) || (x1 > rectX2 && x2 > rectX2) ||
+		(y1 < rectY1 && y2 < rectY1) || (y1 > rectY2 && y2 > rectY2) {
+		return false
+	}
+
+	// Check if the line is horizontal
+	if y1 == y2 {
+		if x1 < rectX1 {
+			*X1 = int(rectX1)
+		} else if x1 > rectX2 {
+			*X1 = int(rectX2)
+		}
+		if x2 < rectX1 {
+			*X2 = int(rectX1)
+		} else if x2 > rectX2 {
+			*X2 = int(rectX2)
+		}
+
+		return true
+	}
+
+	// Check if the line is vertical
+	if x1 == x2 {
+		if y1 < rectY1 {
+			*Y1 = int(rectY1)
+		} else if y1 > rectY2 {
+			*Y1 = int(rectY2)
+		}
+		if y2 < rectY1 {
+			*Y2 = int(rectY1)
+		} else if y2 > rectY2 {
+			*Y2 = int(rectY2)
+		}
+
+		return true
+	}
+
+	// Use Cohen-Sutherland algorithm when all shortcuts fail
+	outCode1 := computeOutCode(a, x1, y1)
+	outCode2 := computeOutCode(a, x2, y2)
+	for outCode1 != 0 || outCode2 != 0 {
+		if outCode1&outCode2 != 0 {
+			return false
+		}
+
+		if outCode1 != 0 {
+			var x, y int32
+			if outCode1&codeTop != 0 {
+				y = rectY1
+				x = x1 + ((x2-x1)*(y-y1))/(y2-y1)
+			} else if outCode1&codeBottom != 0 {
+				y = rectY2
+				x = x1 + ((x2-x1)*(y-y1))/(y2-y1)
+			} else if outCode1&codeLeft != 0 {
+				x = rectX1
+				y = y1 + ((y2-y1)*(x-x1))/(x2-x1)
+			} else if outCode1&codeRight != 0 {
+				x = rectX2
+				y = y1 + ((y2-y1)*(x-x1))/(x2-x1)
+			}
+
+			x1 = x
+			y1 = y
+			outCode1 = computeOutCode(a, x, y)
+		} else {
+			var x, y int32
+			if outCode2&codeTop != 0 {
+				y = rectY1
+				x = x1 + ((x2-x1)*(y-y1))/(y2-y1)
+			} else if outCode2&codeBottom != 0 {
+				y = rectY2
+				x = x1 + ((x2-x1)*(y-y1))/(y2-y1)
+			} else if outCode2&codeLeft != 0 {
+				x = rectX1
+				y = y1 + ((y2-y1)*(x-x1))/(x2-x1)
+			} else if outCode2&codeRight != 0 {
+				x = rectX2
+				y = y1 + ((y2-y1)*(x-x1))/(x2-x1)
+			}
+
+			x2 = x
+			y2 = y
+			outCode2 = computeOutCode(a, x, y)
+		}
+	}
+
+	*X1 = int(x1)
+	*Y1 = int(y1)
+	*X2 = int(x2)
+	*Y2 = int(y2)
+
+	return true
 }

--- a/sdl/rect_test.go
+++ b/sdl/rect_test.go
@@ -4,6 +4,74 @@ import (
 	"testing"
 )
 
+func TestRectHasIntersection(t *testing.T) {
+	var tests = []struct {
+		want bool
+		rA   *Rect
+		rB   *Rect
+	}{
+		{want: true, rA: &Rect{0, 0, 10, 10}, rB: &Rect{6, 7, 6, 7}},
+		{want: false, rA: &Rect{0, 0, 10, 10}, rB: &Rect{20, 20, 5, 5}},
+		{want: false, rA: &Rect{0, 0, 10, 10}, rB: &Rect{10, 0, 5, 5}},
+	}
+
+	for _, test := range tests {
+		if result := test.rA.HasIntersection(test.rB); result != test.want {
+			t.Errorf("%v.HasIntersection(%v) = %v - want %v", test.rA, test.rB, result, test.want)
+		}
+		if result := test.rB.HasIntersection(test.rA); result != test.want {
+			t.Errorf("%v.HasIntersection(%v) = %v - want %v", test.rB, test.rA, result, test.want)
+		}
+	}
+}
+
+func TestRectIntersect(t *testing.T) {
+	var tests = []struct {
+		want   bool
+		rA     *Rect
+		rB     *Rect
+		result Rect
+	}{
+		{want: true, rA: &Rect{0, 0, 10, 10}, rB: &Rect{6, 7, 6, 7}, result: Rect{6, 7, 4, 3}},
+		{want: false, rA: &Rect{0, 0, 10, 10}, rB: &Rect{20, 20, 5, 5}, result: Rect{20, 20, -10, -10}},
+		{want: false, rA: &Rect{0, 0, 10, 10}, rB: &Rect{10, 0, 5, 5}, result: Rect{10, 0, 0, 5}},
+	}
+
+	for _, test := range tests {
+		result, intersects := test.rA.Intersect(test.rB)
+		if intersects != test.want || result != test.result {
+			t.Errorf("%v.Intersects(%v) = %v, %v - want %v, %v", test.rA, test.rB, intersects, result, test.want, test.result)
+		}
+		result, intersects = test.rB.Intersect(test.rA)
+		if intersects != test.want || result != test.result {
+			t.Errorf("%v.Intersects(%v) = %v, %v - want %v, %v", test.rB, test.rA, intersects, result, test.want, test.result)
+		}
+	}
+}
+
+func TestRectUnion(t *testing.T) {
+	var tests = []struct {
+		rA     *Rect
+		rB     *Rect
+		result Rect
+	}{
+		{rA: &Rect{0, 0, 10, 10}, rB: &Rect{6, 7, 6, 7}, result: Rect{0, 0, 12, 14}},
+		{rA: &Rect{0, 0, 10, 10}, rB: &Rect{20, 20, 5, 5}, result: Rect{0, 0, 25, 25}},
+		{rA: &Rect{0, 0, 10, 10}, rB: &Rect{10, 0, 5, 5}, result: Rect{0, 0, 15, 10}},
+	}
+
+	for _, test := range tests {
+		result := test.rA.Union(test.rB)
+		if result != test.result {
+			t.Errorf("%v.Union(%v) = %v - want %v", test.rA, test.rB, result, test.result)
+		}
+		result = test.rB.Union(test.rA)
+		if result != test.result {
+			t.Errorf("%v.Union(%v) = %v - want %v", test.rB, test.rA, result, test.result)
+		}
+	}
+}
+
 func TestRectEmpty(t *testing.T) {
 	var tests = []struct {
 		want bool
@@ -19,6 +87,58 @@ func TestRectEmpty(t *testing.T) {
 	for _, test := range tests {
 		if got := test.r.Empty(); got != test.want {
 			t.Errorf("%#v.Empty() = %v - want %v", test.r, got, test.want)
+		}
+	}
+}
+
+func TestEnclosurePoints(t *testing.T) {
+	var tests = []struct {
+		want      bool
+		points    []Point
+		clip      *Rect
+		enclosure Rect
+	}{
+		{want: false, points: make([]Point, 0), clip: nil, enclosure: Rect{}},
+		{want: true, points: []Point{Point{5, 5}, Point{3, 7}, Point{4, 2}}, clip: nil, enclosure: Rect{3, 2, 3, 6}},
+		{want: true, points: []Point{Point{5, 5}, Point{3, 7}, Point{4, 2}}, clip: &Rect{0, 0, 6, 6}, enclosure: Rect{4, 2, 2, 4}},
+	}
+
+	for _, test := range tests {
+		enclosure, result := EnclosePoints(test.points, test.clip)
+		if enclosure != test.enclosure || result != test.want {
+			t.Errorf("EnclosurePoints(%v, %v) = %v, %v - want %v, %v",
+				test.points, test.clip, enclosure, result, test.enclosure, test.want)
+		}
+	}
+}
+
+func TestIntersectLines(t *testing.T) {
+
+	var tests = []struct {
+		want bool
+		in   struct{ x1, y1, x2, y2 int }
+		out  struct{ x1, y1, x2, y2 int }
+		r    *Rect
+	}{
+		{want: false,
+			in:  struct{ x1, y1, x2, y2 int }{15, 15, 25, 25},
+			out: struct{ x1, y1, x2, y2 int }{15, 15, 25, 25},
+			r:   &Rect{X: 0, Y: 0, W: 10, H: 10}},
+		{want: true,
+			in:  struct{ x1, y1, x2, y2 int }{-1, -1, 11, 11},
+			out: struct{ x1, y1, x2, y2 int }{0, 0, 9, 9},
+			r:   &Rect{X: 0, Y: 0, W: 10, H: 10}}}
+
+	for _, test := range tests {
+		original := test.in
+		if result := test.r.IntersectLine(&test.in.x1, &test.in.y1, &test.in.x2, &test.in.y2); result != test.want {
+			t.Errorf("%v.IntersectLines(%v, %v, %v, %v) = %v - want %v",
+				test.r, original.x1, original.y1, original.x2, original.y2, result, test.want)
+		}
+
+		if test.in != test.out {
+			t.Errorf("%v.IntersectLines(%v, %v, %v, %v) gives %v - want %v",
+				test.r, original.x1, original.y1, original.x2, original.y2, test.in, test.out)
 		}
 	}
 }


### PR DESCRIPTION
This is an implementation of the Rect methods and functions in Go. C is only necessary for Rect to interact with other parts of the library.

I kept the implementation mostly similar to the standard C implementation with a few tweaks to make it more Go-like. The only big change I made was to HasIntersection, which benchmarked better in this form than in the way they did it in C. This suggests more performance improvements could be made.

Tests are provided, but they might benefit from some more cases.