### PR TITLE
Making a better JoystickGetGUIDString interface

### DIFF
--- a/sdl/joystick.go
+++ b/sdl/joystick.go
@@ -59,10 +59,12 @@ func (joy *Joystick) GetGUID() JoystickGUID {
 }
 
 // JoystickGetGUIDString (https://wiki.libsdl.org/SDL_JoystickGetGUIDString)
-func JoystickGetGUIDString(guid JoystickGUID, pszGUID string, cbGUID int) {
-	_pszGUID := C.CString(pszGUID)
-	defer C.free(unsafe.Pointer(_pszGUID))
-	C.SDL_JoystickGetGUIDString(guid.c(), _pszGUID, C.int(cbGUID))
+func JoystickGetGUIDString(guid JoystickGUID) string {
+	_pszGUID := make([]rune, 1024)
+	pszGUID := C.CString(string(_pszGUID[:]))
+	defer C.free(unsafe.Pointer(pszGUID))
+	C.SDL_JoystickGetGUIDString(guid.c(), pszGUID, C.int(unsafe.Sizeof(_pszGUID)))
+	return C.GoString(pszGUID)
 }
 
 // JoystickGetGUIDFromString (https://wiki.libsdl.org/SDL_JoystickGetGUIDFromString)


### PR DESCRIPTION
Hey I was writing a joystick wrapper and noticed that this method did not even work because it didn't take a pointer to a string into the parameters or return anything.

I understand that you are trying to keep the API as close to SDL's implementation but I do not like having to import unsafe to get sizeof when the  JoystickGetGUIDString could do it just fine. I implemented it as
```golang
func JoystickGetGUIDString(guid JoystickGUID) string
```
but it could also be implemented like this
```golang
func JoystickGetGUIDString(guid JoystickGUID, guidstr *string)
```
to keep it closer to SDL but I don't think the size param is necessary for the implementation. 
