### PR TITLE
Multiple changes to audio.go

### DIFF
--- a/examples/audio.go
+++ b/examples/audio.go
@@ -42,6 +42,6 @@ func main() {
 		Callback: sdl.AudioCallback(C.SineWave),
 	}
 	sdl.OpenAudio(spec, nil)
-	sdl.PauseAudio(0)
+	sdl.PauseAudio(false)
 	time.Sleep(1 * time.Second)
 }

--- a/sdl/audio.go
+++ b/sdl/audio.go
@@ -194,10 +194,16 @@ func GetAudioDeviceName(index int, isCapture bool) string {
 }
 
 // OpenAudioDevice (https://wiki.libsdl.org/SDL_OpenAudioDevice)
-func OpenAudioDevice(device string, isCapture bool, desired, obtained *AudioSpec, allowedChanges int) int {
+func OpenAudioDevice(device string, isCapture bool, desired, obtained *AudioSpec, allowedChanges int) (AudioDeviceID, error) {
 	_device := C.CString(device)
+	if device == "" {
+		_device = nil
+	}
 	defer C.free(unsafe.Pointer(_device))
-	return int(C.SDL_OpenAudioDevice(_device, C.int(Btoi(isCapture)), desired.cptr(), obtained.cptr(), C.int(allowedChanges)))
+	if id := AudioDeviceID(C.SDL_OpenAudioDevice(_device, C.int(Btoi(isCapture)), desired.cptr(), obtained.cptr(), C.int(allowedChanges))); id > 0 {
+		return id, nil
+	}
+	return 0, GetError()
 }
 
 // GetAudioStatus (https://wiki.libsdl.org/SDL_GetAudioStatus)

--- a/sdl/audio_test.go
+++ b/sdl/audio_test.go
@@ -50,7 +50,7 @@ func TestLoadWAV_RW(t *testing.T) {
 	// load WAV from *RWOps pointing to WAV data
 	sliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&squareWave))
 	src := RWFromMem(unsafe.Pointer(sliceHeader.Data), len(squareWave))
-	buf, spec := LoadWAV_RW(src, 0, &AudioSpec{})
+	buf, spec := LoadWAV_RW(src, false, &AudioSpec{})
 
 	// test returned []byte
 	want := []byte{0, 0, 0, 0, 255, 255, 255, 255}

--- a/sdl/audio_test.go
+++ b/sdl/audio_test.go
@@ -11,6 +11,24 @@ var squareWave = []byte("RIFF,\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00" +
 	"\x01\x00\xab \x00\x00\xab \x00\x00\x01\x00\b\x00data\b\x00\x00\x00\x00" +
 	"\x00\x00\x00\xff\xff\xff\xff")
 
+func TestAudioDevices(t *testing.T) {
+	for _, isCapture := range []bool{false, true} {
+		n := GetNumAudioDevices(isCapture)
+		for i := 0; i < n; i++ {
+			if GetAudioDeviceName(i, isCapture) == "" {
+				t.Errorf("GetAudioDeviceName(%v, %v) returned empty string",
+					i, isCapture)
+			}
+		}
+
+		// cover GetAudioDeviceName() even if n < 1
+		if name := GetAudioDeviceName(-1, isCapture); name != "" {
+			t.Errorf("GetAudioDeviceName(-1, %v) == %#v; want empty string",
+				isCapture, name)
+		}
+	}
+}
+
 func TestAudioInitQuit(t *testing.T) {
 	// figure out what driver will work
 	if err := InitSubSystem(INIT_AUDIO); err != nil {


### PR DESCRIPTION
The biggest change here was to use `bool`s where appropriate in audio.go functions, and to make sure that an `error` is returned if an error condition is indicated by a C function return value.

The other change was to fix `OpenAudioDevice()`. The first problem was that it returned an `int` instead of an `AudioDeviceID`, so you'd have to do an extra cast before you could actually use that value in any SDL function. The second problem was that there's a (common) special case of passing `NULL` as the device name in C to open the default device, and passing an empty string obviously isn't equivalent.

I would have liked to add more tests, but many audio functions require an `AudioCallback` to use, and cgo isn't supported in tests.