### PR TITLE
sdl_mixer: fix compile error with gccgo

### DIFF
--- a/sdl_mixer/sdl_mixer.go
+++ b/sdl_mixer/sdl_mixer.go
@@ -79,9 +79,7 @@ const (
 const DEFAULT_CHUNKSIZE = 2
 
 // Music (https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer_86.html)
-type Music struct {
-	unsafe.Pointer
-}
+type Music C.Mix_Music
 
 // MusicType (https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer_87.html)
 type MusicType int


### PR DESCRIPTION
With gccgo I was getting this:

    $ go build
    # github.com/veandco/go-sdl2/sdl_mixer
    ./sdl_mixer.go:83:2: error: embedded type may not be a pointer
      unsafe.Pointer
      ^

Apparently upstream Go hasn't yet added the above error[1].

Fixes #167.

[1] https://github.com/golang/go/issues/6357

Signed-off-by: Steven Noonan <steven@uplinklabs.net>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/veandco/go-sdl2/168)
<!-- Reviewable:end -->
