### PR TITLE
Make file variable visible for users

### DIFF
--- a/sdl/events.go
+++ b/sdl/events.go
@@ -342,7 +342,7 @@ type cDollarGestureEvent C.SDL_DollarGestureEvent
 type DropEvent struct {
 	Type      uint32
 	Timestamp uint32
-	file      unsafe.Pointer
+	File      unsafe.Pointer
 }
 type cDropEvent C.SDL_DropEvent
 


### PR DESCRIPTION
Hey,
This way the user can use the File variable which contains the path for drag&drop.
Then it's its responsibility to free File.

p := (*C.char)(t.File)
s := C.GoString(p)
C.free(unsafe.Pointer(p))

Tested on linux x64

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/veandco/go-sdl2/169)
<!-- Reviewable:end -->
