### PR TITLE
[RFC] Put sdl.VERSION(&info.version) inside Window.GetWMInfo().

### DIFF
--- a/examples/syswminfo/syswminfo.go
+++ b/examples/syswminfo/syswminfo.go
@@ -38,7 +38,6 @@ func main() {
 			subsystem = "UIKit"
 		}
 
-		sdl.VERSION(&info.Version)
 		fmt.Printf("This program is running SDL version %d.%d.%d on %s\n",
 			info.Version.Major,
 			info.Version.Minor,

--- a/sdl/syswm.go
+++ b/sdl/syswm.go
@@ -65,6 +65,7 @@ func (info *SysWMInfo) cptr() *C.SDL_SysWMinfo {
 // Window (https://wiki.libsdl.org/SDL_GetWindowWMInfo)
 func (window *Window) GetWMInfo() (*SysWMInfo, error) {
 	var info SysWMInfo
+	VERSION(&info.Version)
 	if C.SDL_GetWindowWMInfo(window.cptr(), info.cptr()) == 0 {
 		return nil, GetError()
 	}


### PR DESCRIPTION
This fixes the `syswminfo` example which currently outputs an error saying `Application not compiled with SDL 2.0` because Window.GetWMInfo() needs to have SysWMInfo initialized with sdl.VERSION().

But I created this PR just in case there's a use-case where you need to use GetWMInfo without sdl.VERSION. If there's comments, then we may have to make Window.GetWMInfo() accept a pointer to a SysWMInfo as one solution. If there's no comments, I'll just merge it in next week and see if people will complain :)

I can merge it sooner of course if people tell me that it's a good idea and they need it to work. Or they can just grab my branch `boen`.

Signed-off-by: Jacky Boen <aqiank@gmail.com>