### PR TITLE
SDL_GetError returns an empty string "" when there are no errors.

### DIFF
--- a/sdl/error.go
+++ b/sdl/error.go
@@ -23,7 +23,11 @@ func (ec ErrorCode) c() C.SDL_errorcode {
 // GetError (https://wiki.libsdl.org/SDL_GetError)
 func GetError() error {
 	if err := C.SDL_GetError(); err != nil {
-		return errors.New(C.GoString(err))
+		gostr := C.GoString(err)
+		// SDL_GetError returns "an empty string if there hasn't been an error message"
+		if len(gostr) > 0 {
+			return errors.New(gostr)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
When trying to use `sdl.GetError()` in an idiomatic go way, it produces unexpected results.
```golang
if err = sdl.GetError(); err != nil {
	// unreachable code
	return fmt.Errorf("SDL error: %v", err)
}
```
Currently it will never return `nil`, because [`SDL_GetError`](https://wiki.libsdl.org/SDL_GetError) always returns at least an empty string.
> Return Value
>
> Returns a message with information about the specific error that occurred, or an empty string if there hasn't been an error message set since the last call to SDL_ClearError(). The message is only applicable when an SDL function has signaled an error. You must check the return values of SDL function calls to determine when to appropriately call SDL_GetError().
> https://wiki.libsdl.org/SDL_GetError

This PR returns `nil` if the length of the string C.SDL_GetError returns was 0.

The workaround is to write non-idiomatic error handling code like this.
```golang
if err = sdl.GetError(); err != nil && len(err.Error()) > 0 { // gross
	return fmt.Errorf("SDL error: %v", err)
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/veandco/go-sdl2/218)
<!-- Reviewable:end -->
