### PR TITLE
Add GetModState that seemed to have been forgotten

### DIFF
--- a/sdl/keyboard.go
+++ b/sdl/keyboard.go
@@ -29,6 +29,11 @@ func GetKeyboardState() []uint8 {
 	return *(*[]uint8)(unsafe.Pointer(&sh))
 }
 
+// GetModState (https://wiki.libsdl.org/SDL_GetModState)
+func GetModState() Keymod {
+	return (Keymod)(C.SDL_GetModState())
+}
+
 // SetModState (https://wiki.libsdl.org/SDL_SetModState)
 func SetModState(mod Keymod) {
 	C.SDL_SetModState(mod.c())


### PR DESCRIPTION
Hi, I don't know why GetModState had been omitted, but it's a very useful function and not too complicated.

And thanks for go-sdl2. Works like a charm on Linux and Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/veandco/go-sdl2/230)
<!-- Reviewable:end -->
