### PR TITLE
sdl/events_test.go: fix crash on macOS

### DIFF
--- a/sdl/events_test.go
+++ b/sdl/events_test.go
@@ -1,8 +1,19 @@
 package sdl
 
 import (
+	"os"
+	"runtime"
 	"testing"
 )
+
+func TestMain(m *testing.M) {
+	// TODO: Find a better way to do this
+
+	runtime.UnlockOSThread() // allow tests to be run on different threads
+	exitcode := m.Run()
+	runtime.LockOSThread() // tests have run, so relock
+	os.Exit(exitcode)
+}
 
 func TestEventsPushEvent(t *testing.T) {
 	Init(INIT_EVERYTHING)


### PR DESCRIPTION
`UnlockOSThread()` before tests run

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/veandco/go-sdl2/247)
<!-- Reviewable:end -->
