### PR TITLE
Ensure right behavior of defer-calls during errors

### DIFF
--- a/examples/audio_mp3/audio_mp3.go
+++ b/examples/audio_mp3/audio_mp3.go
@@ -12,19 +12,19 @@ func main() {
 		log.Println(err)
 		return
 	}
+	defer sdl.Quit()
 
 	if err := mix.Init(mix.INIT_MP3); err != nil {
 		log.Println(err)
 		return
 	}
-	defer sdl.Quit()
 	defer mix.Quit()
-	defer mix.CloseAudio()
 
 	if err := mix.OpenAudio(22050, mix.DEFAULT_FORMAT, 2, 4096); err != nil {
 		log.Println(err)
 		return
 	}
+	defer mix.CloseAudio()
 
 	if music, err := mix.LoadMUS("../../assets/test.mp3"); err != nil {
 		log.Println(err)


### PR DESCRIPTION
Previously, in the case of errors, resource-cleaning defer calls may not run and/or unnecessary defer calls may run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/veandco/go-sdl2/248)
<!-- Reviewable:end -->
