### PR TITLE
go-sdl2/sdl: Force thread-sensitive test code to run in main thread

### DIFF
--- a/sdl/audio_test.go
+++ b/sdl/audio_test.go
@@ -30,38 +30,40 @@ func TestAudioDevices(t *testing.T) {
 }
 
 func TestAudioInitQuit(t *testing.T) {
-	// figure out what driver will work
-	if err := InitSubSystem(INIT_AUDIO); err != nil {
-		t.Fatalf("InitSubSystem(INIT_AUDIO): %v", err)
-	}
-	driver := GetCurrentAudioDriver()
-
-	// reset audio subsystem
-	QuitSubSystem(INIT_AUDIO)
-	if GetCurrentAudioDriver() != "" {
-		t.Fatalf(`GetCurrentAudioDriver() != "" after QuitSubSystem()`)
-	}
-
-	// test valid init
-	if err := AudioInit(driver); err != nil {
-		t.Errorf("AudioInit(%s) returned error: %v", driver, err)
-	} else {
-		if got := GetCurrentAudioDriver(); got != driver {
-			t.Errorf("GetCurrentAudioDriver() == %#v; want %#v", got, driver)
+	Do(func(){
+		// figure out what driver will work
+		if err := InitSubSystem(INIT_AUDIO); err != nil {
+			t.Fatalf("InitSubSystem(INIT_AUDIO): %v", err)
 		}
+		driver := GetCurrentAudioDriver()
 
-		// test quit
-		AudioQuit()
+		// reset audio subsystem
+		QuitSubSystem(INIT_AUDIO)
 		if GetCurrentAudioDriver() != "" {
-			t.Fatalf(`GetCurrentAudioDriver() != "" after AudioQuit()`)
+			t.Fatalf(`GetCurrentAudioDriver() != "" after QuitSubSystem()`)
 		}
-	}
 
-	// test invalid init
-	driver = "bogus"
-	if err := AudioInit(driver); err == nil {
-		t.Errorf("AudioInit(%s) did not return error", driver)
-	}
+		// test valid init
+		if err := AudioInit(driver); err != nil {
+			t.Errorf("AudioInit(%s) returned error: %v", driver, err)
+		} else {
+			if got := GetCurrentAudioDriver(); got != driver {
+				t.Errorf("GetCurrentAudioDriver() == %#v; want %#v", got, driver)
+			}
+
+			// test quit
+			AudioQuit()
+			if GetCurrentAudioDriver() != "" {
+				t.Fatalf(`GetCurrentAudioDriver() != "" after AudioQuit()`)
+			}
+		}
+
+		// test invalid init
+		driver = "bogus"
+		if err := AudioInit(driver); err == nil {
+			t.Errorf("AudioInit(%s) did not return error", driver)
+		}
+	})
 }
 
 func TestLoadWAV_RW(t *testing.T) {

--- a/sdl/clipboard_test.go
+++ b/sdl/clipboard_test.go
@@ -3,27 +3,29 @@ package sdl
 import "testing"
 
 func TestClipboard(t *testing.T) {
-	Init(INIT_VIDEO)
-	defer Quit()
+	Do(func(){
+		Init(INIT_VIDEO)
+		defer Quit()
 
-	// need a window to own the clipboard
-	if win, err := CreateWindow("", 0, 0, 0, 0, 0); err == nil {
-		defer win.Destroy()
-	} else {
-		t.Skipf("Could not CreateWindow(): %v", err)
-	}
+		// need a window to own the clipboard
+		if win, err := CreateWindow("", 0, 0, 0, 0, 0); err == nil {
+			defer win.Destroy()
+		} else {
+			t.Skipf("Could not CreateWindow(): %v", err)
+		}
 
-	wantString, wantBool := []string{"", "naïveté"}, []bool{false, true}
-	for i := 0; i < 2; i++ {
-		if err := SetClipboardText(wantString[i]); err != nil {
-			t.Skipf("Could not SetClipboardText(): %v", err)
+		wantString, wantBool := []string{"", "naïveté"}, []bool{false, true}
+		for i := 0; i < 2; i++ {
+			if err := SetClipboardText(wantString[i]); err != nil {
+				t.Skipf("Could not SetClipboardText(): %v", err)
+			}
+			if got := HasClipboardText(); got != wantBool[i] {
+				t.Errorf("HasClipboardText() == %v; want %v", got, wantBool[i])
+			}
+			if got, err := GetClipboardText(); err == nil && got != wantString[i] {
+				t.Errorf("GetClipboardText() == (nil, %#v); want (nil, %#v)",
+					got, wantString[i])
+			}
 		}
-		if got := HasClipboardText(); got != wantBool[i] {
-			t.Errorf("HasClipboardText() == %v; want %v", got, wantBool[i])
-		}
-		if got, err := GetClipboardText(); err == nil && got != wantString[i] {
-			t.Errorf("GetClipboardText() == (nil, %#v); want (nil, %#v)",
-				got, wantString[i])
-		}
-	}
+	})
 }

--- a/sdl/filesystem_test.go
+++ b/sdl/filesystem_test.go
@@ -5,14 +5,16 @@ import (
 )
 
 func TestGetBasePath(t *testing.T) {
-	Init(INIT_EVERYTHING)
-	path := GetBasePath()
-	// pathetic, but a comparison to runtime.Caller() does not help here,
-	// since this would return go's testing package
-	if path == "" {
-		t.Error("GetBasePath() did not return anything")
-	}
-	Quit()
+	Do(func() {
+		Init(INIT_EVERYTHING)
+		path := GetBasePath()
+		// pathetic, but a comparison to runtime.Caller() does not help here,
+		// since this would return go's testing package
+		if path == "" {
+			t.Error("GetBasePath() did not return anything")
+		}
+		Quit()
+	})
 }
 
 // Do not test GetPrefPath(), since SDL_GetPrefPath() also

--- a/sdl/hints_test.go
+++ b/sdl/hints_test.go
@@ -8,61 +8,66 @@ const (
 )
 
 func TestSetHintWithPriority(t *testing.T) {
-	Init(INIT_EVERYTHING)
-	defer Quit()
+	Do(func() {
+		Init(INIT_EVERYTHING)
+		defer Quit()
 
-	if !SetHintWithPriority(HINT_TIMER_RESOLUTION, TIMER_RESOLUTION, HINT_DEFAULT) {
-		t.Errorf("return value for SetHintWithPriority(HINT_TIMER_RESOLUTION, TIMER_RESOLUTION, HINT_DEFAULT) is wrong")
-	}
-	if GetHint(HINT_TIMER_RESOLUTION) != TIMER_RESOLUTION {
-		t.Errorf("SetHintWithPriority() did not set value properly")
-	}
-	if !SetHintWithPriority(HINT_RENDER_DRIVER, DRIVER, HINT_NORMAL) {
-		t.Errorf("return value for SetHintWithPriority(HINT_RENDER_DRIVER, 'software', HINT_NORMAL) is wrong")
-	}
-	if GetHint(HINT_RENDER_DRIVER) != DRIVER {
-		t.Errorf("SetHintWithPriority() [HINT_NORMAL] did not set value properly")
-	}
-	if SetHintWithPriority(HINT_RENDER_DRIVER, DRIVER, HINT_DEFAULT) {
-		t.Errorf("return value for SetHintWithPriority(HINT_RENDER_DRIVER, DRIVER, HINT_DEFAULT) is wrong")
-	}
-	if GetHint(HINT_RENDER_DRIVER) != DRIVER {
-		t.Errorf("SetHintWithPriority() [HINT_DEFAULT] did not set value properly")
-	}
-
+		if !SetHintWithPriority(HINT_TIMER_RESOLUTION, TIMER_RESOLUTION, HINT_DEFAULT) {
+			t.Errorf("return value for SetHintWithPriority(HINT_TIMER_RESOLUTION, TIMER_RESOLUTION, HINT_DEFAULT) is wrong")
+		}
+		if GetHint(HINT_TIMER_RESOLUTION) != TIMER_RESOLUTION {
+			t.Errorf("SetHintWithPriority() did not set value properly")
+		}
+		if !SetHintWithPriority(HINT_RENDER_DRIVER, DRIVER, HINT_NORMAL) {
+			t.Errorf("return value for SetHintWithPriority(HINT_RENDER_DRIVER, 'software', HINT_NORMAL) is wrong")
+		}
+		if GetHint(HINT_RENDER_DRIVER) != DRIVER {
+			t.Errorf("SetHintWithPriority() [HINT_NORMAL] did not set value properly")
+		}
+		if SetHintWithPriority(HINT_RENDER_DRIVER, DRIVER, HINT_DEFAULT) {
+			t.Errorf("return value for SetHintWithPriority(HINT_RENDER_DRIVER, DRIVER, HINT_DEFAULT) is wrong")
+		}
+		if GetHint(HINT_RENDER_DRIVER) != DRIVER {
+			t.Errorf("SetHintWithPriority() [HINT_DEFAULT] did not set value properly")
+		}
+	})
 }
 
 func TestGetSetHint(t *testing.T) {
-	Init(INIT_EVERYTHING)
-	defer Quit()
+	Do(func() {
+		Init(INIT_EVERYTHING)
+		defer Quit()
 
-	if !SetHint(HINT_TIMER_RESOLUTION, TIMER_RESOLUTION) {
-		t.Errorf("return value for SetHint(HINT_TIMER_RESOLUTION, RESOLUTION) is wrong")
-	}
-	if GetHint(HINT_TIMER_RESOLUTION) != TIMER_RESOLUTION {
-		t.Errorf("return value for GetHint(HINT_TIMER_RESOLUTION) is wrong")
-	}
+		if !SetHint(HINT_TIMER_RESOLUTION, TIMER_RESOLUTION) {
+			t.Errorf("return value for SetHint(HINT_TIMER_RESOLUTION, RESOLUTION) is wrong")
+		}
+		if GetHint(HINT_TIMER_RESOLUTION) != TIMER_RESOLUTION {
+			t.Errorf("return value for GetHint(HINT_TIMER_RESOLUTION) is wrong")
+		}
 
-	if !SetHint(HINT_RENDER_DRIVER, DRIVER) {
-		t.Errorf("return value for SetHint(HINT_RENDER_DRIVER, DRIVER) is wrong")
-	}
-	if GetHint(HINT_RENDER_DRIVER) != DRIVER {
-		t.Errorf("return value for GetHint(HINT_RENDER_DRIVER) is wrong")
-	}
+		if !SetHint(HINT_RENDER_DRIVER, DRIVER) {
+			t.Errorf("return value for SetHint(HINT_RENDER_DRIVER, DRIVER) is wrong")
+		}
+		if GetHint(HINT_RENDER_DRIVER) != DRIVER {
+			t.Errorf("return value for GetHint(HINT_RENDER_DRIVER) is wrong")
+		}
+	})
 }
 
 func TestClearHints(t *testing.T) {
-	Init(INIT_EVERYTHING)
-	defer Quit()
+	Do(func() {
+		Init(INIT_EVERYTHING)
+		defer Quit()
 
-	if !SetHint(HINT_TIMER_RESOLUTION, TIMER_RESOLUTION) {
-		t.Errorf("return value for SetHint(HINT_TIMER_RESOLUTION, TIMER_RESOLUTION) is wrong")
-	}
-	if GetHint(HINT_TIMER_RESOLUTION) != TIMER_RESOLUTION {
-		t.Errorf("return value for GetHint(HINT_TIMER_RESOLUTION) is wrong")
-	}
-	ClearHints()
-	if GetHint(HINT_TIMER_RESOLUTION) != "" {
-		t.Errorf("return value for GetHint(HINT_TIMER_RESOLUTION) after ClearHints() is wrong")
-	}
+		if !SetHint(HINT_TIMER_RESOLUTION, TIMER_RESOLUTION) {
+			t.Errorf("return value for SetHint(HINT_TIMER_RESOLUTION, TIMER_RESOLUTION) is wrong")
+		}
+		if GetHint(HINT_TIMER_RESOLUTION) != TIMER_RESOLUTION {
+			t.Errorf("return value for GetHint(HINT_TIMER_RESOLUTION) is wrong")
+		}
+		ClearHints()
+		if GetHint(HINT_TIMER_RESOLUTION) != "" {
+			t.Errorf("return value for GetHint(HINT_TIMER_RESOLUTION) after ClearHints() is wrong")
+		}
+	})
 }

--- a/sdl/surface_test.go
+++ b/sdl/surface_test.go
@@ -5,46 +5,48 @@ import (
 )
 
 func TestSurface(t *testing.T) {
-	var window *Window
-	var surface *Surface
-	var image *Surface
-	var err error
+	Do(func() {
+		var window *Window
+		var surface *Surface
+		var image *Surface
+		var err error
 
-	Init(INIT_EVERYTHING)
-	defer Quit()
+		Init(INIT_EVERYTHING)
+		defer Quit()
 
-	if window, err = CreateWindow("Hello!", 100, 100, 800, 600, WINDOW_SHOWN); err != nil {
-		t.Error(err)
-	}
-	defer window.Destroy()
+		if window, err = CreateWindow("Hello!", 100, 100, 800, 600, WINDOW_SHOWN); err != nil {
+			t.Error(err)
+		}
+		defer window.Destroy()
 
-	if surface, err = window.GetSurface(); err != nil {
-		t.Error(err)
-	}
+		if surface, err = window.GetSurface(); err != nil {
+			t.Error(err)
+		}
 
-	pixels := surface.Pixels()
-	for i := range pixels {
-		pixels[i] = 0xFF
-	}
+		pixels := surface.Pixels()
+		for i := range pixels {
+			pixels[i] = 0xFF
+		}
 
-	if err = window.UpdateSurface(); err != nil {
-		t.Error(err)
-	}
+		if err = window.UpdateSurface(); err != nil {
+			t.Error(err)
+		}
 
-	Delay(50)
+		Delay(50)
 
-	if image, err = LoadBMP("../assets/test.bmp"); err != nil {
-		t.Error(err)
-	}
-	defer image.Free()
+		if image, err = LoadBMP("../assets/test.bmp"); err != nil {
+			t.Error(err)
+		}
+		defer image.Free()
 
-	if err = image.Blit(&Rect{0, 0, 512, 512}, surface, &Rect{0, 0, 512, 512}); err != nil {
-		t.Error(err)
-	}
+		if err = image.Blit(&Rect{0, 0, 512, 512}, surface, &Rect{0, 0, 512, 512}); err != nil {
+			t.Error(err)
+		}
 
-	if err = window.UpdateSurface(); err != nil {
-		t.Error(err)
-	}
+		if err = window.UpdateSurface(); err != nil {
+			t.Error(err)
+		}
 
-	Delay(50)
+		Delay(50)
+	})
 }

--- a/sdl/video_test.go
+++ b/sdl/video_test.go
@@ -5,28 +5,30 @@ import (
 )
 
 func TestWindow(t *testing.T) {
-	var window *Window
-	var err error
+	Do(func() {
+		var window *Window
+		var err error
 
-	Init(INIT_EVERYTHING)
-	defer Quit()
+		Init(INIT_EVERYTHING)
+		defer Quit()
 
-	if window, err = CreateWindow("Hello!", 100, 100, 800, 600, WINDOW_SHOWN); err != nil {
-		t.Error(err)
-	}
-	defer window.Destroy()
+		if window, err = CreateWindow("Hello!", 100, 100, 800, 600, WINDOW_SHOWN); err != nil {
+			t.Error(err)
+		}
+		defer window.Destroy()
 
-	if title := window.GetTitle(); title != "Hello!" {
-		t.Error("Window title is incorrect!")
-	}
+		if title := window.GetTitle(); title != "Hello!" {
+			t.Error("Window title is incorrect!")
+		}
 
-	if x, y := window.GetPosition(); x != 100 || y != 100 {
-		t.Error("Window position is incorrect!")
-	}
+		if x, y := window.GetPosition(); x != 100 || y != 100 {
+			t.Error("Window position is incorrect!")
+		}
 
-	if w, h := window.GetSize(); w != 800 || h != 600 {
-		t.Error("Window size is incorrect!")
-	}
+		if w, h := window.GetSize(); w != 800 || h != 600 {
+			t.Error("Window size is incorrect!")
+		}
 
-	Delay(100)
+		Delay(100)
+	})
 }


### PR DESCRIPTION
Wrapped possible problematic test codes in `Do(..)`. Running `go test -v -race` no longer fails on macOS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/veandco/go-sdl2/250)
<!-- Reviewable:end -->
