### PR TITLE
examples/render_*: fix premature os.Exit(..) calls

### DIFF
--- a/examples/render_goroutines/render_goroutines.go
+++ b/examples/render_goroutines/render_goroutines.go
@@ -109,7 +109,14 @@ func run() int {
 }
 
 func main() {
+	// os.Exit(..) must run AFTER sdl.Main(..) below; so keep track of exit
+	// status manually outside the closure passed into sdl.Main(..) below
+	var exitcode int
 	sdl.Main(func() {
-		os.Exit(run())
+		exitcode = run()
 	})
+	// os.Exit(..) must run here! If run in sdl.Main(..) above, it will cause
+	// premature quitting of sdl.Main(..) function; resource cleaning deferred
+	// calls/closing of channels may never run
+	os.Exit(exitcode)
 }

--- a/examples/render_queue/render_queue.go
+++ b/examples/render_queue/render_queue.go
@@ -143,7 +143,14 @@ func run() int {
 }
 
 func main() {
+	// os.Exit(..) must run AFTER sdl.Main(..) below; so keep track of exit
+	// status manually outside the closure passed into sdl.Main(..) below
+	var exitcode int
 	sdl.Main(func() {
-		os.Exit(run())
+		exitcode = run()
 	})
+	// os.Exit(..) must run here! If run in sdl.Main(..) above, it will cause
+	// premature quitting of sdl.Main(..) function; resource cleaning deferred
+	// calls/closing of channels may never run
+	os.Exit(exitcode)
 }

--- a/sdl/sdl.go
+++ b/sdl/sdl.go
@@ -52,6 +52,7 @@ func Main(main func()) {
 	exitch := make(chan bool, 1)
 	go func() {
 		main()
+		// fmt.Println("END") // to check if os.Exit(..) is called by main() above
 		exitch <- true
 	}()
 	for {


### PR DESCRIPTION
Calls to `os.Exit(..)` within closure passed into `sdl.Main(..)` can cause premature end of main thread. The rest of the code inside `sdl.Main(..)` will never get to run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/veandco/go-sdl2/251)
<!-- Reviewable:end -->
