### PR TITLE
gfx: Correct GetFramecount call

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@ SRCDIR=		${CURDIR}
 ALLDIRS!=	find ${SRCDIR} -type d -not -path "./.git*"
 # Packages
 ROOTPKG=	$(subst ${GOPATH}/src/,,${SRCDIR})
-PACKAGES=	sdl img mix ttf
+PACKAGES=	sdl img mix ttf gfx
 # Some cleanups
 CLEANUP=	*.cache *.core *~ *.orig
 

--- a/gfx/sdl_gfx.go
+++ b/gfx/sdl_gfx.go
@@ -64,7 +64,7 @@ func GetFramerate(manager *FPSmanager) (int, bool) {
 }
 
 func GetFramecount(manager *FPSmanager) (int, bool) {
-	count := int(C.SDL_getFramerate(manager.cptr()))
+	count := int(C.SDL_getFramecount(manager.cptr()))
 	return count, count >= 0
 }
 

--- a/gfx/sdl_gfx_test.go
+++ b/gfx/sdl_gfx_test.go
@@ -13,3 +13,29 @@ func TestMin(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestFPSmanager(t *testing.T) {
+	fpsManager := FPSmanager{}
+	InitFramerate(&fpsManager)
+
+	if !SetFramerate(&fpsManager, 60) {
+		t.Errorf("gfx.SetFramerate failed")
+	}
+
+	if fps, ok := GetFramerate(&fpsManager); !ok || fps != 60 {
+		t.Errorf("gfx.GetFramerate() = (%v, %v) - want (60, true)", fps, ok)
+	}
+
+	// frame count is initialized to 0
+	if count, ok := GetFramecount(&fpsManager); !ok || count != 0 {
+		t.Errorf("gfx.GetFramecount() = (%v, %v) - want (0, true)", count, ok)
+	}
+
+	// count one frame
+	FramerateDelay(&fpsManager)
+
+	// frame count should now be 1
+	if count, ok := GetFramecount(&fpsManager); !ok || count != 1 {
+		t.Errorf("gfx.Framecount() = (%v, %v) - want (1, true)", count, ok)
+	}
+}


### PR DESCRIPTION
- Update `gfx.GetFramecount` to correctly call `SDL_getFramecount`
- Add `gfx` to the makefile package list (so gfx tests are run)
- Add tests for the FPSmanager

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/veandco/go-sdl2/258)
<!-- Reviewable:end -->
