### PR TITLE
 sdl: render: Rename GL_BindTexture() and GL_UnbindTexture() to GLBind() and GLUnbind()

### DIFF
--- a/sdl/render.go
+++ b/sdl/render.go
@@ -5,7 +5,7 @@ package sdl
 
 #if !(SDL_VERSION_ATLEAST(2,0,1))
 #pragma message("SDL_UpdateYUVTexture is not supported before SDL 2.0.1")
-static inline char* SDL_UpdateYUVTexture(SDL_Texture* texture, const SDL_Rect* rect, const Uint8* Yplane, int Ypitch, const Uint8* Uplane, int Upitch, const Uint8* Vplane, int Vpitch)
+static inline int SDL_UpdateYUVTexture(SDL_Texture* texture, const SDL_Rect* rect, const Uint8* Yplane, int Ypitch, const Uint8* Uplane, int Upitch, const Uint8* Vplane, int Vpitch)
 {
 	return -1;
 }

--- a/sdl/render.go
+++ b/sdl/render.go
@@ -1,6 +1,17 @@
 package sdl
 
-// #include "sdl_wrapper.h"
+/*
+#include "sdl_wrapper.h"
+
+#if !(SDL_VERSION_ATLEAST(2,0,1))
+#pragma message("SDL_UpdateYUVTexture is not supported before SDL 2.0.1")
+static inline char* SDL_UpdateYUVTexture()
+{
+	return NULL;
+}
+#endif
+
+*/
 import "C"
 import "reflect"
 import "unsafe"

--- a/sdl/render.go
+++ b/sdl/render.go
@@ -240,6 +240,21 @@ func (texture *Texture) Update(rect *Rect, pixels []byte, pitch int) error {
 	return nil
 }
 
+// Texture (https://wiki.libsdl.org/SDL_UpdateYUVTexture)
+func (texture *Texture) UpdateYUV(rect *Rect, yPlane []byte, yPitch int, uPlane []byte, uPitch int, vPlane []byte, vPitch int) error {
+	_yPlane := (*C.Uint8)(unsafe.Pointer(&yPlane[0]))
+	_yPitch := C.int(yPitch)
+	_uPlane := (*C.Uint8)(unsafe.Pointer(&uPlane[0]))
+	_uPitch := C.int(uPitch)
+	_vPlane := (*C.Uint8)(unsafe.Pointer(&vPlane[0]))
+	_vPitch := C.int(vPitch)
+	_ret := C.SDL_UpdateYUVTexture(texture.cptr(), rect.cptr(), _yPlane, _yPitch, _uPlane, _uPitch, _vPlane, _vPitch)
+	if _ret < 0 {
+		return GetError()
+	}
+	return nil
+}
+
 // Texture (https://wiki.libsdl.org/SDL_LockTexture)
 func (texture *Texture) Lock(rect *Rect) ([]byte, int, error) {
 	var _pitch C.int

--- a/sdl/render.go
+++ b/sdl/render.go
@@ -570,7 +570,8 @@ func (renderer *Renderer) Destroy() {
 	C.SDL_DestroyRenderer(renderer.cptr())
 }
 
-func (texture *Texture) GL_BindTexture(texw, texh *float32) error {
+// Texture (https://wiki.libsdl.org/SDL_GL_BindTexture)
+func (texture *Texture) GLBind(texw, texh *float32) error {
 	_texw := (*C.float)(unsafe.Pointer(texw))
 	_texh := (*C.float)(unsafe.Pointer(texh))
 	_ret := C.SDL_GL_BindTexture(texture.cptr(), _texw, _texh)
@@ -580,7 +581,8 @@ func (texture *Texture) GL_BindTexture(texw, texh *float32) error {
 	return nil
 }
 
-func (texture *Texture) GL_UnbindTexture() error {
+// Texture (https://wiki.libsdl.org/SDL_GL_UnbindTexture)
+func (texture *Texture) GLUnbind() error {
 	_ret := C.SDL_GL_UnbindTexture(texture.cptr())
 	if _ret < 0 {
 		return GetError()

--- a/sdl/render.go
+++ b/sdl/render.go
@@ -5,9 +5,9 @@ package sdl
 
 #if !(SDL_VERSION_ATLEAST(2,0,1))
 #pragma message("SDL_UpdateYUVTexture is not supported before SDL 2.0.1")
-static inline char* SDL_UpdateYUVTexture()
+static inline char* SDL_UpdateYUVTexture(SDL_Texture* texture, const SDL_Rect* rect, const Uint8* Yplane, int Ypitch, const Uint8* Uplane, int Upitch, const Uint8* Vplane, int Vpitch)
 {
-	return NULL;
+	return -1;
 }
 #endif
 


### PR DESCRIPTION
Removed objects name from it's methods. Removed underscores.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/veandco/go-sdl2/266)
<!-- Reviewable:end -->
