### PR TITLE
 sdl: audio, render: Add documentation

### DIFF
--- a/sdl/audio.go
+++ b/sdl/audio.go
@@ -32,34 +32,43 @@ import (
 	"unsafe"
 )
 
+// Audio format masks.
+// (https://wiki.libsdl.org/SDL_AudioFormat)
 const (
-	AUDIO_MASK_BITSIZE  = C.SDL_AUDIO_MASK_BITSIZE
-	AUDIO_MASK_DATATYPE = C.SDL_AUDIO_MASK_DATATYPE
-	AUDIO_MASK_ENDIAN   = C.SDL_AUDIO_MASK_ENDIAN
-	AUDIO_MASK_SIGNED   = C.SDL_AUDIO_MASK_SIGNED
+	AUDIO_MASK_BITSIZE  = C.SDL_AUDIO_MASK_BITSIZE  // (0xFF)
+	AUDIO_MASK_DATATYPE = C.SDL_AUDIO_MASK_DATATYPE // (1<<8)
+	AUDIO_MASK_ENDIAN   = C.SDL_AUDIO_MASK_ENDIAN   // (1<<12)
+	AUDIO_MASK_SIGNED   = C.SDL_AUDIO_MASK_SIGNED   // (1<<15)
 )
 
+// Audio format values.
+// (https://wiki.libsdl.org/SDL_AudioFormat)
 const (
-	AUDIO_U8     = C.AUDIO_U8
-	AUDIO_S8     = C.AUDIO_S8
-	AUDIO_U16LSB = C.AUDIO_U16LSB
-	AUDIO_S16LSB = C.AUDIO_S16LSB
-	AUDIO_U16MSB = C.AUDIO_U16MSB
-	AUDIO_S16MSB = C.AUDIO_S16MSB
-	AUDIO_U16    = C.AUDIO_U16
-	AUDIO_S16    = C.AUDIO_S16
-	AUDIO_S32LSB = C.AUDIO_S32LSB
-	AUDIO_S32MSB = C.AUDIO_S32MSB
-	AUDIO_S32    = C.AUDIO_S32
-	AUDIO_F32LSB = C.AUDIO_F32LSB
-	AUDIO_F32MSB = C.AUDIO_F32MSB
-	AUDIO_F32    = C.AUDIO_F32
-	AUDIO_U16SYS = C.AUDIO_U16SYS
-	AUDIO_S16SYS = C.AUDIO_S16SYS
-	AUDIO_S32SYS = C.AUDIO_S32SYS
-	AUDIO_F32SYS = C.AUDIO_F32SYS
+	AUDIO_S8 = C.AUDIO_S8 // unsigned 8-bit samples
+	AUDIO_U8 = C.AUDIO_U8 // signed 8-bit samples
+
+	AUDIO_S16LSB = C.AUDIO_S16LSB // signed 16-bit samples in little-endian byte order
+	AUDIO_S16MSB = C.AUDIO_S16MSB // signed 16-bit samples in big-endian byte order
+	AUDIO_S16SYS = C.AUDIO_S16SYS // signed 16-bit samples in native byte order
+	AUDIO_S16    = C.AUDIO_S16    // AUDIO_S16LSB
+	AUDIO_U16LSB = C.AUDIO_U16LSB // unsigned 16-bit samples in little-endian byte order
+	AUDIO_U16MSB = C.AUDIO_U16MSB // unsigned 16-bit samples in big-endian byte order
+	AUDIO_U16SYS = C.AUDIO_U16SYS // unsigned 16-bit samples in native byte order
+	AUDIO_U16    = C.AUDIO_U16    // AUDIO_U16LSB
+
+	AUDIO_S32LSB = C.AUDIO_S32LSB // 32-bit integer samples in little-endian byte order
+	AUDIO_S32MSB = C.AUDIO_S32MSB // 32-bit integer samples in big-endian byte order
+	AUDIO_S32SYS = C.AUDIO_S32SYS // 32-bit integer samples in native byte order
+	AUDIO_S32    = C.AUDIO_S32    // AUDIO_S32LSB
+
+	AUDIO_F32LSB = C.AUDIO_F32LSB // 32-bit floating point samples in little-endian byte order
+	AUDIO_F32MSB = C.AUDIO_F32MSB // 32-bit floating point samples in big-endian byte order
+	AUDIO_F32SYS = C.AUDIO_F32SYS // 32-bit floating point samples in native byte order
+	AUDIO_F32    = C.AUDIO_F32    // AUDIO_F32LSB
 )
 
+// AllowedChanges flags specify how SDL should behave when a device cannot offer a specific feature. If the application requests a feature that the hardware doesn't offer, SDL will always try to get the closest equivalent. Used in OpenAudioDevice().
+// (https://wiki.libsdl.org/SDL_OpenAudioDevice)
 const (
 	AUDIO_ALLOW_FREQUENCY_CHANGE = C.SDL_AUDIO_ALLOW_FREQUENCY_CHANGE
 	AUDIO_ALLOW_FORMAT_CHANGE    = C.SDL_AUDIO_ALLOW_FORMAT_CHANGE
@@ -67,51 +76,68 @@ const (
 	AUDIO_ALLOW_ANY_CHANGE       = C.SDL_AUDIO_ALLOW_ANY_CHANGE
 )
 
+// An enumeration of audio device states used in GetAudioDeviceStatus() and GetAudioStatus().
+// (https://wiki.libsdl.org/SDL_AudioStatus)
 const (
-	AUDIO_STOPPED AudioStatus = C.SDL_AUDIO_STOPPED
-	AUDIO_PLAYING             = C.SDL_AUDIO_PLAYING
-	AUDIO_PAUSED              = C.SDL_AUDIO_PAUSED
+	AUDIO_STOPPED AudioStatus = C.SDL_AUDIO_STOPPED // audio device is stopped
+	AUDIO_PLAYING             = C.SDL_AUDIO_PLAYING // audio device is playing
+	AUDIO_PAUSED              = C.SDL_AUDIO_PAUSED  // audio device is paused
 )
 
-const MIX_MAXVOLUME = C.SDL_MIX_MAXVOLUME
+// MIX_MAXVOLUME is the full audio volume value used in MixAudioFormat() and AudioFormat().
+// (https://wiki.libsdl.org/SDL_MixAudioFormat)
+const MIX_MAXVOLUME = C.SDL_MIX_MAXVOLUME // full audio volume
 
-// AudioFormat (https://wiki.libsdl.org/SDL_AudioFormat)
+// AudioFormat is an enumeration of audio formats.
+// (https://wiki.libsdl.org/SDL_AudioFormat)
 type AudioFormat uint16
+
+// AudioCallback is a function to call when the audio device needs more data.`
+// (https://wiki.libsdl.org/SDL_AudioSpec)
 type AudioCallback C.SDL_AudioCallback
+
+// AudioFilter is the filter list used in AudioCVT() (internal use)
+// (https://wiki.libsdl.org/SDL_AudioCVT)
 type AudioFilter C.SDL_AudioFilter
+
+// AudioDeviceID is ID of an audio device previously opened with OpenAudioDevice().
+// (https://wiki.libsdl.org/SDL_OpenAudioDevice)
 type AudioDeviceID uint32
 
-// AudioStatus (https://wiki.libsdl.org/SDL_AudioStatus)
+// AudioStatus is an enumeration of audio device states.
+// (https://wiki.libsdl.org/SDL_AudioStatus)
 type AudioStatus uint32
 type cAudioStatus C.SDL_AudioStatus
 
-// AudioSpec (https://wiki.libsdl.org/SDL_AudioSpec)
+// AudioSpec contains the audio output format. It also contains a callback that is called when the audio device needs more data.
+// (https://wiki.libsdl.org/SDL_AudioSpec)
 type AudioSpec struct {
-	Freq     int32
-	Format   AudioFormat
-	Channels uint8
-	Silence  uint8
-	Samples  uint16
-	Padding  uint16
-	Size     uint32
-	Callback AudioCallback
-	UserData unsafe.Pointer
+	Freq     int32          // DSP frequency (samples per second)
+	Format   AudioFormat    // audio data format
+	Channels uint8          // number of separate sound channels
+	Silence  uint8          // audio buffer silence value (calculated)
+	Samples  uint16         // audio buffer size in samples (power of 2)
+	padding  uint16         // necessary for some compile environments (internal use)
+	Size     uint32         // audio buffer size in bytes (calculated)
+	Callback AudioCallback  // the function to call when the audio device needs more data
+	UserData unsafe.Pointer // a pointer that is passed to callback (otherwise ignored by SDL)
 }
 type cAudioSpec C.SDL_AudioSpec
 
-// AudioCVT (https://wiki.libsdl.org/SDL_AudioCVT)
+// AudioCVT contains audio data conversion information.
+// (https://wiki.libsdl.org/SDL_AudioCVT)
 type AudioCVT struct {
-	Needed      int32
-	SrcFormat   AudioFormat
-	DstFormat   AudioFormat
-	RateIncr    float64
-	Buf         unsafe.Pointer // use AudioCVT.BufAsSlice() for access via Go slice
-	Len         int32
-	LenCVT      int32
-	LenMult     int32
-	LenRatio    float64
-	filters     [10]AudioFilter // internal
-	filterIndex int32           // internal
+	Needed      int32           // set to 1 if conversion possible
+	SrcFormat   AudioFormat     // source audio format
+	DstFormat   AudioFormat     // target audio format
+	RateIncr    float64         // rate conversion increment
+	Buf         unsafe.Pointer  // the buffer to hold entire audio data. Use AudioCVT.BufAsSlice() for access via a Go slice
+	Len         int32           // length of original audio buffer
+	LenCVT      int32           // length of converted audio buffer
+	LenMult     int32           // buf must be len*len_mult big
+	LenRatio    float64         // given len, final size is len*len_ratio
+	filters     [10]AudioFilter // filter list (internal use)
+	filterIndex int32           // current audio conversion function (internal use)
 }
 type cAudioCVT C.SDL_AudioCVT
 
@@ -131,44 +157,60 @@ func (cvt *AudioCVT) cptr() *C.SDL_AudioCVT {
 	return (*C.SDL_AudioCVT)(unsafe.Pointer(cvt))
 }
 
-func (format AudioFormat) BitSize() uint8 {
-	return uint8(format & AUDIO_MASK_BITSIZE)
+// BitSize returns audio formats bit size.
+// (https://wiki.libsdl.org/SDL_AudioFormat)
+func (fmt AudioFormat) BitSize() uint8 {
+	return uint8(fmt & AUDIO_MASK_BITSIZE)
 }
 
-func (format AudioFormat) IsFloat() bool {
-	return (format & AUDIO_MASK_DATATYPE) > 0
+// IsFloat reports whether audio format is float.
+// (https://wiki.libsdl.org/SDL_AudioFormat)
+func (fmt AudioFormat) IsFloat() bool {
+	return (fmt & AUDIO_MASK_DATATYPE) > 0
 }
 
-func (format AudioFormat) IsBigEndian() bool {
-	return (format & AUDIO_MASK_ENDIAN) > 0
+// IsBigEndian reports whether audio format is big-endian.
+// (https://wiki.libsdl.org/SDL_AudioFormat)
+func (fmt AudioFormat) IsBigEndian() bool {
+	return (fmt & AUDIO_MASK_ENDIAN) > 0
 }
 
-func (format AudioFormat) IsSigned() bool {
-	return (format & AUDIO_MASK_SIGNED) > 0
+// IsSigned reports whether audio format is signed.
+// (https://wiki.libsdl.org/SDL_AudioFormat)
+func (fmt AudioFormat) IsSigned() bool {
+	return (fmt & AUDIO_MASK_SIGNED) > 0
 }
 
-func (format AudioFormat) IsInt() bool {
-	return !format.IsFloat()
+// IsInt reports whether audio format is integer.
+// (https://wiki.libsdl.org/SDL_AudioFormat)
+func (fmt AudioFormat) IsInt() bool {
+	return !fmt.IsFloat()
 }
 
-func (format AudioFormat) IsLittleEndian() bool {
-	return !format.IsBigEndian()
+// IsLittleEndian reports whether audio format is little-endian.
+// (https://wiki.libsdl.org/SDL_AudioFormat)
+func (fmt AudioFormat) IsLittleEndian() bool {
+	return !fmt.IsBigEndian()
 }
 
-func (format AudioFormat) IsUnsigned() bool {
-	return !format.IsSigned()
+// IsUnsigned reports whether audio format is unsigned.
+// (https://wiki.libsdl.org/SDL_AudioFormat)
+func (fmt AudioFormat) IsUnsigned() bool {
+	return !fmt.IsSigned()
 }
 
+// AllocBuf allocates the requested memory for AudioCVT buffer.
 func (cvt *AudioCVT) AllocBuf(size uintptr) {
 	cvt.Buf = C.malloc(C.size_t(size))
 }
 
+// FreeBuf deallocates the memory previously allocated from AudioCVT buffer.
 func (cvt *AudioCVT) FreeBuf() {
 	C.free(cvt.Buf)
 }
 
-// Access AudioCVT.buf as slice.
-// NOTE: Must have used ConvertAudio() before usage because it uses LenCVT as slice length.
+// BufAsSlice returns AudioCVT.buf as byte slice.
+// NOTE: Must be used after ConvertAudio() because it uses LenCVT as slice length.
 func (cvt AudioCVT) BufAsSlice() []byte {
 	var b []byte
 	sliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&b))
@@ -178,17 +220,20 @@ func (cvt AudioCVT) BufAsSlice() []byte {
 	return b
 }
 
-// GetNumAudioDrivers (https://wiki.libsdl.org/SDL_GetNumAudioDrivers)
+// GetNumAudioDrivers returns the number of built-in audio drivers.
+// (https://wiki.libsdl.org/SDL_GetNumAudioDrivers)
 func GetNumAudioDrivers() int {
 	return int(C.SDL_GetNumAudioDrivers())
 }
 
-// GetAudioDriver (https://wiki.libsdl.org/SDL_GetAudioDriver)
+// GetAudioDriver returns the name of a built in audio driver.
+// (https://wiki.libsdl.org/SDL_GetAudioDriver)
 func GetAudioDriver(index int) string {
 	return string(C.GoString(C.SDL_GetAudioDriver(C.int(index))))
 }
 
-// AudioInit (https://wiki.libsdl.org/SDL_AudioInit)
+// AudioInit initializes a particular audio driver.
+// (https://wiki.libsdl.org/SDL_AudioInit)
 func AudioInit(driverName string) error {
 	_driverName := C.CString(driverName)
 	defer C.free(unsafe.Pointer(_driverName))
@@ -198,17 +243,20 @@ func AudioInit(driverName string) error {
 	return nil
 }
 
-// AudioQuit (https://wiki.libsdl.org/SDL_AudioQuit)
+// AudioQuit shuts down audio if you initialized it with AudioInit().
+// (https://wiki.libsdl.org/SDL_AudioQuit)
 func AudioQuit() {
 	C.SDL_AudioQuit()
 }
 
-// GetCurrentAudioDriver (https://wiki.libsdl.org/SDL_GetCurrentAudioDriver)
+// GetCurrentAudioDriver returns the name of the current audio driver.
+// (https://wiki.libsdl.org/SDL_GetCurrentAudioDriver)
 func GetCurrentAudioDriver() string {
 	return string(C.GoString(C.SDL_GetCurrentAudioDriver()))
 }
 
-// OpenAudio (https://wiki.libsdl.org/SDL_OpenAudio)
+// OpenAudio opens the audio device. New programs might want to use OpenAudioDevice() instead.
+// (https://wiki.libsdl.org/SDL_OpenAudio)
 func OpenAudio(desired, obtained *AudioSpec) error {
 	if C.SDL_OpenAudio(desired.cptr(), obtained.cptr()) != 0 {
 		return GetError()
@@ -216,17 +264,20 @@ func OpenAudio(desired, obtained *AudioSpec) error {
 	return nil
 }
 
-// GetNumAudioDevices (https://wiki.libsdl.org/SDL_GetNumAudioDevices)
+// GetNumAudioDevices returns the number of built-in audio devices.
+// (https://wiki.libsdl.org/SDL_GetNumAudioDevices)
 func GetNumAudioDevices(isCapture bool) int {
 	return int(C.SDL_GetNumAudioDevices(C.int(Btoi(isCapture))))
 }
 
-// GetAudioDeviceName (https://wiki.libsdl.org/SDL_GetAudioDeviceName)
+// GetAudioDeviceName returns the name of a specific audio device.
+// (https://wiki.libsdl.org/SDL_GetAudioDeviceName)
 func GetAudioDeviceName(index int, isCapture bool) string {
 	return string(C.GoString(C.SDL_GetAudioDeviceName(C.int(index), C.int(Btoi(isCapture)))))
 }
 
-// OpenAudioDevice (https://wiki.libsdl.org/SDL_OpenAudioDevice)
+// OpenAudioDevice opens a specific audio device.
+// (https://wiki.libsdl.org/SDL_OpenAudioDevice)
 func OpenAudioDevice(device string, isCapture bool, desired, obtained *AudioSpec, allowedChanges int) (AudioDeviceID, error) {
 	_device := C.CString(device)
 	if device == "" {
@@ -239,28 +290,33 @@ func OpenAudioDevice(device string, isCapture bool, desired, obtained *AudioSpec
 	return 0, GetError()
 }
 
-// GetAudioStatus (https://wiki.libsdl.org/SDL_GetAudioStatus)
+// GetAudioStatus returns the current audio state of the audio device. New programs might want to use GetAudioDeviceStatus() instead.
+// (https://wiki.libsdl.org/SDL_GetAudioStatus)
 func GetAudioStatus() AudioStatus {
 	return (AudioStatus)(C.SDL_GetAudioStatus())
 }
 
-// GetAudioDeviceStatus (https://wiki.libsdl.org/SDL_GetAudioDeviceStatus)
+// GetAudioDeviceStatus returns the current audio state of an audio device.
+// (https://wiki.libsdl.org/SDL_GetAudioDeviceStatus)
 func GetAudioDeviceStatus(dev AudioDeviceID) AudioStatus {
 	return (AudioStatus)(C.SDL_GetAudioDeviceStatus(dev.c()))
 }
 
-// PauseAudio (https://wiki.libsdl.org/SDL_PauseAudio)
+// PauseAudio pauses and unpauses the audio device. New programs might want to use SDL_PauseAudioDevice() instead.
+// (https://wiki.libsdl.org/SDL_PauseAudio)
 func PauseAudio(pauseOn bool) {
 	C.SDL_PauseAudio(C.int(Btoi(pauseOn)))
 }
 
-// PauseAudioDevice (https://wiki.libsdl.org/SDL_PauseAudioDevice)
+// PauseAudioDevice pauses and unpauses audio playback on a specified device.
+// (https://wiki.libsdl.org/SDL_PauseAudioDevice)
 func PauseAudioDevice(dev AudioDeviceID, pauseOn bool) {
 	C.SDL_PauseAudioDevice(dev.c(), C.int(Btoi(pauseOn)))
 }
 
-// LoadWAV_RW (https://wiki.libsdl.org/SDL_LoadWAV_RW)
-func LoadWAV_RW(src *RWops, freeSrc bool, spec *AudioSpec) ([]byte, *AudioSpec) {
+// LoadWAVRW loads a WAVE from the data source, automatically freeing that source if freeSrc is true.
+// (https://wiki.libsdl.org/SDL_LoadWAV_RW)
+func LoadWAVRW(src *RWops, freeSrc bool, spec *AudioSpec) ([]byte, *AudioSpec) {
 	var _audioBuf *C.Uint8
 	var _audioLen C.Uint32
 	audioSpec := (*AudioSpec)(unsafe.Pointer(C.SDL_LoadWAV_RW(src.cptr(), C.int(Btoi(freeSrc)), spec.cptr(), &_audioBuf, &_audioLen)))
@@ -273,7 +329,8 @@ func LoadWAV_RW(src *RWops, freeSrc bool, spec *AudioSpec) ([]byte, *AudioSpec) 
 	return b, audioSpec
 }
 
-// LoadWAV (https://wiki.libsdl.org/SDL_LoadWAV)
+// LoadWAV loads a WAVE from a file.
+// (https://wiki.libsdl.org/SDL_LoadWAV)
 func LoadWAV(file string, spec *AudioSpec) ([]byte, *AudioSpec) {
 	_file := C.CString(file)
 	_rb := C.CString("rb")
@@ -292,14 +349,16 @@ func LoadWAV(file string, spec *AudioSpec) ([]byte, *AudioSpec) {
 	return b, audioSpec
 }
 
-// FreeWAV (https://wiki.libsdl.org/SDL_FreeWAV)
+// FreeWAV frees data previously allocated with LoadWAV() or LoadWAVRW().
+// (https://wiki.libsdl.org/SDL_FreeWAV)
 func FreeWAV(audioBuf []uint8) {
 	sliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&audioBuf))
 	_audioBuf := (*C.Uint8)(unsafe.Pointer(sliceHeader.Data))
 	C.SDL_FreeWAV(_audioBuf)
 }
 
-// BuildAudioCVT (https://wiki.libsdl.org/SDL_BuildAudioCVT)
+// BuildAudioCVT initializes an AudioCVT structure for conversion.
+// (https://wiki.libsdl.org/SDL_BuildAudioCVT)
 func BuildAudioCVT(cvt *AudioCVT, srcFormat AudioFormat, srcChannels uint8, srcRate int, dstFormat AudioFormat, dstChannels uint8, dstRate int) (converted bool, err error) {
 	switch int(C.SDL_BuildAudioCVT(cvt.cptr(), srcFormat.c(), C.Uint8(srcChannels), C.int(srcRate), dstFormat.c(), C.Uint8(dstChannels), C.int(dstRate))) {
 	case 1:
@@ -310,7 +369,8 @@ func BuildAudioCVT(cvt *AudioCVT, srcFormat AudioFormat, srcChannels uint8, srcR
 	return false, GetError()
 }
 
-// ConvertAudio (https://wiki.libsdl.org/SDL_ConvertAudio)
+// ConvertAudio converts audio data to a desired audio format.
+// (https://wiki.libsdl.org/SDL_ConvertAudio)
 func ConvertAudio(cvt *AudioCVT) error {
 	_cvt := (*C.SDL_AudioCVT)(unsafe.Pointer(cvt))
 	if C.SDL_ConvertAudio(_cvt) != 0 {
@@ -319,7 +379,8 @@ func ConvertAudio(cvt *AudioCVT) error {
 	return nil
 }
 
-// QueueAudio (https://wiki.libsdl.org/SDL_QueueAudio)
+// QueueAudio queues more audio on non-callback devices.
+// (https://wiki.libsdl.org/SDL_QueueAudio)
 func QueueAudio(dev AudioDeviceID, data []byte) error {
 	sliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&data))
 	_data := unsafe.Pointer(sliceHeader.Data)
@@ -330,7 +391,8 @@ func QueueAudio(dev AudioDeviceID, data []byte) error {
 	return nil
 }
 
-// DequeueAudio (https://wiki.libsdl.org/SDL_DequeueAudio)
+// DequeueAudio dequeues more audio on non-callback devices.
+// (https://wiki.libsdl.org/SDL_DequeueAudio)
 func DequeueAudio(dev AudioDeviceID, data []byte) error {
 	sliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&data))
 	_data := unsafe.Pointer(sliceHeader.Data)
@@ -341,56 +403,66 @@ func DequeueAudio(dev AudioDeviceID, data []byte) error {
 	return nil
 }
 
-// GetQueuedAudioSize (https://wiki.libsdl.org/SDL_GetQueuedAudioSize)
+// GetQueuedAudioSize returns the number of bytes of still-queued audio.
+// (https://wiki.libsdl.org/SDL_GetQueuedAudioSize)
 func GetQueuedAudioSize(dev AudioDeviceID) uint32 {
 	return uint32(C.SDL_GetQueuedAudioSize(dev.c()))
 }
 
-// ClearQueuedAudio (https://wiki.libsdl.org/SDL_ClearQueuedAudio)
+// ClearQueuedAudio drops any queued audio data waiting to be sent to the hardware.
+// (https://wiki.libsdl.org/SDL_ClearQueuedAudio)
 func ClearQueuedAudio(dev AudioDeviceID) {
 	C.SDL_ClearQueuedAudio(dev.c())
 }
 
-// MixAudio (https://wiki.libsdl.org/SDL_MixAudio)
-func MixAudio(dst, src *uint8, len_ uint32, volume int) {
+// MixAudio mixes audio data. New programs might want to use MixAudioFormat() instead.
+// (https://wiki.libsdl.org/SDL_MixAudio)
+func MixAudio(dst, src *uint8, len uint32, volume int) {
 	_dst := (*C.Uint8)(unsafe.Pointer(dst))
 	_src := (*C.Uint8)(unsafe.Pointer(src))
-	C.SDL_MixAudio(_dst, _src, C.Uint32(len_), C.int(volume))
+	C.SDL_MixAudio(_dst, _src, C.Uint32(len), C.int(volume))
 }
 
-// MixAudioFormat (https://wiki.libsdl.org/SDL_MixAudioFormat)
-func MixAudioFormat(dst, src *uint8, format AudioFormat, len_ uint32, volume int) {
+// MixAudioFormat mixes audio data in a specified format.
+// (https://wiki.libsdl.org/SDL_MixAudioFormat)
+func MixAudioFormat(dst, src *uint8, format AudioFormat, len uint32, volume int) {
 	_dst := (*C.Uint8)(unsafe.Pointer(dst))
 	_src := (*C.Uint8)(unsafe.Pointer(src))
-	C.SDL_MixAudioFormat(_dst, _src, format.c(), C.Uint32(len_), C.int(volume))
+	C.SDL_MixAudioFormat(_dst, _src, format.c(), C.Uint32(len), C.int(volume))
 }
 
-// LockAudio (https://wiki.libsdl.org/SDL_LockAudio)
+// LockAudio locks the audio device. New programs might want to use LockAudioDevice() instead.
+// (https://wiki.libsdl.org/SDL_LockAudio)
 func LockAudio() {
 	C.SDL_LockAudio()
 }
 
-// LockAudioDevice (https://wiki.libsdl.org/SDL_LockAudioDevice)
+// LockAudioDevice locks out the audio callback function for a specified device.
+// (https://wiki.libsdl.org/SDL_LockAudioDevice)
 func LockAudioDevice(dev AudioDeviceID) {
 	C.SDL_LockAudioDevice(dev.c())
 }
 
-// UnlockAudio (https://wiki.libsdl.org/SDL_UnlockAudio)
+// UnlockAudio unlocks the audio device. New programs might want to use UnlockAudioDevice() instead.
+// (https://wiki.libsdl.org/SDL_UnlockAudio)
 func UnlockAudio() {
 	C.SDL_UnlockAudio()
 }
 
-// UnlockAudioDevice (https://wiki.libsdl.org/SDL_UnlockAudioDevice)
+// UnlockAudioDevice unlocks the audio callback function for a specified device.
+// (https://wiki.libsdl.org/SDL_UnlockAudioDevice)
 func UnlockAudioDevice(dev AudioDeviceID) {
 	C.SDL_UnlockAudioDevice(dev.c())
 }
 
-// CloseAudio (https://wiki.libsdl.org/SDL_CloseAudio)
+// CloseAudio closes the audio device. New programs might want to use CloseAudioDevice() instead.
+// (https://wiki.libsdl.org/SDL_CloseAudio)
 func CloseAudio() {
 	C.SDL_CloseAudio()
 }
 
-// CloseAudioDevice (https://wiki.libsdl.org/SDL_CloseAudioDevice)
+// CloseAudioDevice shuts down audio processing and closes the audio device.
+// (https://wiki.libsdl.org/SDL_CloseAudioDevice)
 func CloseAudioDevice(dev AudioDeviceID) {
 	C.SDL_CloseAudioDevice(dev.c())
 }

--- a/sdl/render.go
+++ b/sdl/render.go
@@ -5,7 +5,7 @@ package sdl
 
 #if !(SDL_VERSION_ATLEAST(2,0,1))
 #pragma message("SDL_UpdateYUVTexture is not supported before SDL 2.0.1")
-static inline char* SDL_UpdateYUVTexture(SDL_Texture* texture, const SDL_Rect* rect, const Uint8* Yplane, int Ypitch, const Uint8* Uplane, int Upitch, const Uint8* Vplane, int Vpitch)
+static inline int SDL_UpdateYUVTexture(SDL_Texture* texture, const SDL_Rect* rect, const Uint8* Yplane, int Ypitch, const Uint8* Uplane, int Upitch, const Uint8* Vplane, int Vpitch)
 {
 	return -1;
 }

--- a/sdl/render.go
+++ b/sdl/render.go
@@ -1,6 +1,17 @@
 package sdl
 
-// #include "sdl_wrapper.h"
+/*
+#include "sdl_wrapper.h"
+
+#if !(SDL_VERSION_ATLEAST(2,0,1))
+#pragma message("SDL_UpdateYUVTexture is not supported before SDL 2.0.1")
+static inline char* SDL_UpdateYUVTexture()
+{
+	return NULL;
+}
+#endif
+
+*/
 import "C"
 import "reflect"
 import "unsafe"

--- a/sdl/render.go
+++ b/sdl/render.go
@@ -240,6 +240,21 @@ func (texture *Texture) Update(rect *Rect, pixels []byte, pitch int) error {
 	return nil
 }
 
+// Texture (https://wiki.libsdl.org/SDL_UpdateYUVTexture)
+func (texture *Texture) UpdateYUV(rect *Rect, yPlane []byte, yPitch int, uPlane []byte, uPitch int, vPlane []byte, vPitch int) error {
+	_yPlane := (*C.Uint8)(unsafe.Pointer(&yPlane[0]))
+	_yPitch := C.int(yPitch)
+	_uPlane := (*C.Uint8)(unsafe.Pointer(&uPlane[0]))
+	_uPitch := C.int(uPitch)
+	_vPlane := (*C.Uint8)(unsafe.Pointer(&vPlane[0]))
+	_vPitch := C.int(vPitch)
+	_ret := C.SDL_UpdateYUVTexture(texture.cptr(), rect.cptr(), _yPlane, _yPitch, _uPlane, _uPitch, _vPlane, _vPitch)
+	if _ret < 0 {
+		return GetError()
+	}
+	return nil
+}
+
 // Texture (https://wiki.libsdl.org/SDL_LockTexture)
 func (texture *Texture) Lock(rect *Rect) ([]byte, int, error) {
 	var _pitch C.int

--- a/sdl/render.go
+++ b/sdl/render.go
@@ -570,7 +570,8 @@ func (renderer *Renderer) Destroy() {
 	C.SDL_DestroyRenderer(renderer.cptr())
 }
 
-func (texture *Texture) GL_BindTexture(texw, texh *float32) error {
+// Texture (https://wiki.libsdl.org/SDL_GL_BindTexture)
+func (texture *Texture) GLBind(texw, texh *float32) error {
 	_texw := (*C.float)(unsafe.Pointer(texw))
 	_texh := (*C.float)(unsafe.Pointer(texh))
 	_ret := C.SDL_GL_BindTexture(texture.cptr(), _texw, _texh)
@@ -580,7 +581,8 @@ func (texture *Texture) GL_BindTexture(texw, texh *float32) error {
 	return nil
 }
 
-func (texture *Texture) GL_UnbindTexture() error {
+// Texture (https://wiki.libsdl.org/SDL_GL_UnbindTexture)
+func (texture *Texture) GLUnbind() error {
 	_ret := C.SDL_GL_UnbindTexture(texture.cptr())
 	if _ret < 0 {
 		return GetError()

--- a/sdl/render.go
+++ b/sdl/render.go
@@ -37,7 +37,8 @@ const (
 	FLIP_VERTICAL                = C.SDL_FLIP_VERTICAL
 )
 
-// RendererInfo (https://wiki.libsdl.org/SDL_RendererInfo)
+// RendererInfo contains information on the capabilities of a render driver or the current render context.
+// (https://wiki.libsdl.org/SDL_RendererInfo)
 type RendererInfo struct {
 	Name string
 	RendererInfoData
@@ -64,7 +65,8 @@ func (info *cRendererInfo) cptr() *C.SDL_RendererInfo {
 	return (*C.SDL_RendererInfo)(unsafe.Pointer(info))
 }
 
-// RendererFlip (https://wiki.libsdl.org/SDL_RendererFlip)
+// RendererFlip is an enumeration of flags that can be used in the flip parameter for Renderer.CopyEx().
+// (https://wiki.libsdl.org/SDL_RendererFlip)
 type RendererFlip uint32
 type cRendererFlip C.SDL_RendererFlip
 
@@ -72,12 +74,14 @@ func (flip RendererFlip) c() C.SDL_RendererFlip {
 	return C.SDL_RendererFlip(flip)
 }
 
-// GetNumRenderDrivers (https://wiki.libsdl.org/SDL_GetNumRenderDrivers)
+// GetNumRenderDrivers returns the number of 2D rendering drivers available for the current display.
+// (https://wiki.libsdl.org/SDL_GetNumRenderDrivers)
 func GetNumRenderDrivers() int {
 	return int(C.SDL_GetNumRenderDrivers())
 }
 
-// GetRenderDriverInfo (https://wiki.libsdl.org/SDL_GetRenderDriverInfo)
+// GetRenderDriverInfo returns information about a specific 2D rendering driver for the current display.
+// (https://wiki.libsdl.org/SDL_GetRenderDriverInfo)
 func GetRenderDriverInfo(index int, info *RendererInfo) int {
 	var cinfo cRendererInfo
 	ret := int(C.SDL_GetRenderDriverInfo(C.int(index), cinfo.cptr()))
@@ -89,7 +93,8 @@ func GetRenderDriverInfo(index int, info *RendererInfo) int {
 	return ret
 }
 
-// CreateWindowAndRenderer (https://wiki.libsdl.org/SDL_CreateWindowAndRenderer)
+// CreateWindowAndRenderer returns a new window and default renderer.
+// (https://wiki.libsdl.org/SDL_CreateWindowAndRenderer)
 func CreateWindowAndRenderer(w, h int, flags uint32) (*Window, *Renderer, error) {
 	var window *C.SDL_Window
 	var renderer *C.SDL_Renderer
@@ -100,7 +105,8 @@ func CreateWindowAndRenderer(w, h int, flags uint32) (*Window, *Renderer, error)
 	return (*Window)(unsafe.Pointer(window)), (*Renderer)(unsafe.Pointer(renderer)), nil
 }
 
-// CreateRenderer (https://wiki.libsdl.org/SDL_CreateRenderer)
+// CreateRenderer returns a new 2D rendering context for a window.
+// (https://wiki.libsdl.org/SDL_CreateRenderer)
 func CreateRenderer(window *Window, index int, flags uint32) (*Renderer, error) {
 	_renderer := C.SDL_CreateRenderer(window.cptr(), C.int(index), C.Uint32(flags))
 	if _renderer == nil {
@@ -109,7 +115,8 @@ func CreateRenderer(window *Window, index int, flags uint32) (*Renderer, error) 
 	return (*Renderer)(unsafe.Pointer(_renderer)), nil
 }
 
-// CreateSoftwareRenderer (https://wiki.libsdl.org/SDL_CreateSoftwareRenderer)
+// CreateSoftwareRenderer returns a new 2D software rendering context for a surface.
+// (https://wiki.libsdl.org/SDL_CreateSoftwareRenderer)
 func CreateSoftwareRenderer(surface *Surface) (*Renderer, error) {
 	_renderer := C.SDL_CreateSoftwareRenderer(surface.cptr())
 	if _renderer == nil {
@@ -118,7 +125,8 @@ func CreateSoftwareRenderer(surface *Surface) (*Renderer, error) {
 	return (*Renderer)(unsafe.Pointer(_renderer)), nil
 }
 
-// Window (https://wiki.libsdl.org/SDL_GetRenderer)
+// GetRenderer returns the renderer associated with a window.
+// (https://wiki.libsdl.org/SDL_GetRenderer)
 func (window *Window) GetRenderer() (*Renderer, error) {
 	_renderer := C.SDL_GetRenderer(window.cptr())
 	if _renderer == nil {
@@ -127,7 +135,8 @@ func (window *Window) GetRenderer() (*Renderer, error) {
 	return (*Renderer)(unsafe.Pointer(_renderer)), nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_GetRendererInfo)
+// GetInfo returns information about a rendering context.
+// (https://wiki.libsdl.org/SDL_GetRendererInfo)
 func (renderer *Renderer) GetInfo() (RendererInfo, error) {
 	var cinfo cRendererInfo
 	var info RendererInfo
@@ -143,7 +152,8 @@ func (renderer *Renderer) GetInfo() (RendererInfo, error) {
 	return info, nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_GetRendererOutputSize)
+// GetOutputSize returns the output size in pixels of a rendering context.
+// (https://wiki.libsdl.org/SDL_GetRendererOutputSize)
 func (renderer *Renderer) GetOutputSize() (w, h int, err error) {
 	_w := (*C.int)(unsafe.Pointer(&w))
 	_h := (*C.int)(unsafe.Pointer(&h))
@@ -154,7 +164,8 @@ func (renderer *Renderer) GetOutputSize() (w, h int, err error) {
 	return
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_CreateTexture)
+// CreateTexture returns a new texture for a rendering context.
+// (https://wiki.libsdl.org/SDL_CreateTexture)
 func (renderer *Renderer) CreateTexture(format uint32, access int, w int, h int) (*Texture, error) {
 	_format := C.Uint32(format)
 	_access := C.int(access)
@@ -167,7 +178,8 @@ func (renderer *Renderer) CreateTexture(format uint32, access int, w int, h int)
 	return (*Texture)(unsafe.Pointer(_texture)), nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_CreateTextureFromSurface)
+// CreateTextureFromSurface returns a new texture from an existing surface.
+// (https://wiki.libsdl.org/SDL_CreateTextureFromSurface)
 func (renderer *Renderer) CreateTextureFromSurface(surface *Surface) (*Texture, error) {
 	_texture := C.SDL_CreateTextureFromSurface(renderer.cptr(), surface.cptr())
 	if _texture == nil {
@@ -176,7 +188,8 @@ func (renderer *Renderer) CreateTextureFromSurface(surface *Surface) (*Texture, 
 	return (*Texture)(unsafe.Pointer(_texture)), nil
 }
 
-// Texture (https://wiki.libsdl.org/SDL_QueryTexture)
+// Query returns the attributes of a texture.
+// (https://wiki.libsdl.org/SDL_QueryTexture)
 func (texture *Texture) Query() (uint32, int, int32, int32, error) {
 	var format C.Uint32
 	var access C.int
@@ -189,7 +202,8 @@ func (texture *Texture) Query() (uint32, int, int32, int32, error) {
 	return uint32(format), int(access), int32(width), int32(height), nil
 }
 
-// Texture (https://wiki.libsdl.org/SDL_SetTextureColorMod)
+// SetColorMod sets an additional color value multiplied into render copy operations.
+// (https://wiki.libsdl.org/SDL_SetTextureColorMod)
 func (texture *Texture) SetColorMod(r uint8, g uint8, b uint8) error {
 	_r := C.Uint8(r)
 	_g := C.Uint8(g)
@@ -201,7 +215,8 @@ func (texture *Texture) SetColorMod(r uint8, g uint8, b uint8) error {
 	return nil
 }
 
-// Texture (https://wiki.libsdl.org/SDL_SetTextureAlphaMod)
+// SetAlphaMod sets an additional alpha value multiplied into render copy operations.
+// (https://wiki.libsdl.org/SDL_SetTextureAlphaMod)
 func (texture *Texture) SetAlphaMod(alpha uint8) error {
 	_ret := C.SDL_SetTextureAlphaMod(texture.cptr(), C.Uint8(alpha))
 	if _ret < 0 {
@@ -210,7 +225,8 @@ func (texture *Texture) SetAlphaMod(alpha uint8) error {
 	return nil
 }
 
-// Texture (https://wiki.libsdl.org/SDL_GetTextureAlphaMod)
+// GetAlphaMod returns the additional alpha value multiplied into render copy operations.
+// (https://wiki.libsdl.org/SDL_GetTextureAlphaMod)
 func (texture *Texture) GetAlphaMod() (alpha uint8, err error) {
 	_alpha := (*C.Uint8)(unsafe.Pointer(&alpha))
 	_ret := C.SDL_GetTextureAlphaMod(texture.cptr(), _alpha)
@@ -221,7 +237,8 @@ func (texture *Texture) GetAlphaMod() (alpha uint8, err error) {
 	return alpha, nil
 }
 
-// Texture (https://wiki.libsdl.org/SDL_SetTextureBlendMode)
+// SetBlendMode sets the blend mode for a texture, used by Renderer.Copy().
+// (https://wiki.libsdl.org/SDL_SetTextureBlendMode)
 func (texture *Texture) SetBlendMode(bm BlendMode) error {
 	_ret := C.SDL_SetTextureBlendMode(texture.cptr(), bm.c())
 	if _ret < 0 {
@@ -230,7 +247,8 @@ func (texture *Texture) SetBlendMode(bm BlendMode) error {
 	return nil
 }
 
-// Texture (https://wiki.libsdl.org/SDL_GetTextureBlendMode)
+// GetBlendMode returns the blend mode used for texture copy operations.
+// (https://wiki.libsdl.org/SDL_GetTextureBlendMode)
 func (texture *Texture) GetBlendMode() (bm BlendMode, err error) {
 	_ret := C.SDL_GetTextureBlendMode(texture.cptr(), bm.cptr())
 	if _ret < 0 {
@@ -240,7 +258,8 @@ func (texture *Texture) GetBlendMode() (bm BlendMode, err error) {
 	return bm, nil
 }
 
-// Texture (https://wiki.libsdl.org/SDL_UpdateTexture)
+// Update updates the given texture rectangle with new pixel data.
+// (https://wiki.libsdl.org/SDL_UpdateTexture)
 func (texture *Texture) Update(rect *Rect, pixels []byte, pitch int) error {
 	_pixels := unsafe.Pointer(&pixels[0])
 	_pitch := C.int(pitch)
@@ -251,7 +270,8 @@ func (texture *Texture) Update(rect *Rect, pixels []byte, pitch int) error {
 	return nil
 }
 
-// Texture (https://wiki.libsdl.org/SDL_UpdateYUVTexture)
+// UpdateYUV updates a rectangle within a planar YV12 or IYUV texture with new pixel data.
+// (https://wiki.libsdl.org/SDL_UpdateYUVTexture)
 func (texture *Texture) UpdateYUV(rect *Rect, yPlane []byte, yPitch int, uPlane []byte, uPitch int, vPlane []byte, vPitch int) error {
 	_yPlane := (*C.Uint8)(unsafe.Pointer(&yPlane[0]))
 	_yPitch := C.int(yPitch)
@@ -266,7 +286,8 @@ func (texture *Texture) UpdateYUV(rect *Rect, yPlane []byte, yPitch int, uPlane 
 	return nil
 }
 
-// Texture (https://wiki.libsdl.org/SDL_LockTexture)
+// Lock locks a portion of the texture for write-only pixel access.
+// (https://wiki.libsdl.org/SDL_LockTexture)
 func (texture *Texture) Lock(rect *Rect) ([]byte, int, error) {
 	var _pitch C.int
 	var _pixels unsafe.Pointer
@@ -297,17 +318,20 @@ func (texture *Texture) Lock(rect *Rect) ([]byte, int, error) {
 	return b, int(pitch), nil
 }
 
-// Texture (https://wiki.libsdl.org/SDL_UnlockTexture)
+// Unlock unlocks a texture, uploading the changes to video memory, if needed.
+// (https://wiki.libsdl.org/SDL_UnlockTexture)
 func (texture *Texture) Unlock() {
 	C.SDL_UnlockTexture(texture.cptr())
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderTargetSupported)
+// RenderTargetSupported reports whether a window supports the use of render targets.
+// (https://wiki.libsdl.org/SDL_RenderTargetSupported)
 func (renderer *Renderer) RenderTargetSupported() bool {
 	return C.SDL_RenderTargetSupported(renderer.cptr()) != 0
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_SetRenderTarget)
+// SetRenderTarget sets a texture as the current rendering target.
+// (https://wiki.libsdl.org/SDL_SetRenderTarget)
 func (renderer *Renderer) SetRenderTarget(texture *Texture) error {
 	_ret := C.SDL_SetRenderTarget(renderer.cptr(), texture.cptr())
 	if _ret < 0 {
@@ -316,12 +340,14 @@ func (renderer *Renderer) SetRenderTarget(texture *Texture) error {
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_GetRenderTarget)
+// GetRenderTarget returns the current render target.
+// (https://wiki.libsdl.org/SDL_GetRenderTarget)
 func (renderer *Renderer) GetRenderTarget() *Texture {
 	return (*Texture)(unsafe.Pointer(C.SDL_GetRenderTarget(renderer.cptr())))
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderSetLogicalSize)
+// SetLogicalSize sets a device independent resolution for rendering.
+// (https://wiki.libsdl.org/SDL_RenderSetLogicalSize)
 func (renderer *Renderer) SetLogicalSize(w int, h int) error {
 	_ret := C.SDL_RenderSetLogicalSize(renderer.cptr(), C.int(w), C.int(h))
 	if _ret < 0 {
@@ -330,7 +356,8 @@ func (renderer *Renderer) SetLogicalSize(w int, h int) error {
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderGetLogicalSize)
+// GetLogicalSize Use returns device independent resolution for rendering.
+// (https://wiki.libsdl.org/SDL_RenderGetLogicalSize)
 func (renderer *Renderer) GetLogicalSize() (w, h int) {
 	_w := (*C.int)(unsafe.Pointer(&w))
 	_h := (*C.int)(unsafe.Pointer(&h))
@@ -338,7 +365,8 @@ func (renderer *Renderer) GetLogicalSize() (w, h int) {
 	return
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderSetViewport)
+// SetViewport sets the drawing area for rendering on the current target.
+// (https://wiki.libsdl.org/SDL_RenderSetViewport)
 func (renderer *Renderer) SetViewport(rect *Rect) error {
 	_ret := C.SDL_RenderSetViewport(renderer.cptr(), rect.cptr())
 	if _ret < 0 {
@@ -347,12 +375,14 @@ func (renderer *Renderer) SetViewport(rect *Rect) error {
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderGetViewport)
+// GetViewport returns the drawing area for the current target.
+// (https://wiki.libsdl.org/SDL_RenderGetViewport)
 func (renderer *Renderer) GetViewport(rect *Rect) {
 	C.SDL_RenderGetViewport(renderer.cptr(), rect.cptr())
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderSetClipRect)
+// SetClipRect sets the clip rectangle for rendering on the specified target.
+// (https://wiki.libsdl.org/SDL_RenderSetClipRect)
 func (renderer *Renderer) SetClipRect(rect *Rect) error {
 	_ret := C.SDL_RenderSetClipRect(renderer.cptr(), rect.cptr())
 	if _ret < 0 {
@@ -361,12 +391,14 @@ func (renderer *Renderer) SetClipRect(rect *Rect) error {
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderGetClipRect)
+// GetClipRect returns the clip rectangle for the current target.
+// (https://wiki.libsdl.org/SDL_RenderGetClipRect)
 func (renderer *Renderer) GetClipRect(rect *Rect) {
 	C.SDL_RenderGetClipRect(renderer.cptr(), rect.cptr())
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderSetScale)
+// SetScale sets the drawing scale for rendering on the current target.
+// (https://wiki.libsdl.org/SDL_RenderSetScale)
 func (renderer *Renderer) SetScale(scaleX, scaleY float32) error {
 	_scaleX := C.float(scaleX)
 	_scaleY := C.float(scaleY)
@@ -377,7 +409,8 @@ func (renderer *Renderer) SetScale(scaleX, scaleY float32) error {
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderGetScale)
+// GetScale returns the drawing scale for the current target.
+// (https://wiki.libsdl.org/SDL_RenderGetScale)
 func (renderer *Renderer) GetScale() (scaleX, scaleY float32) {
 	_scaleX := (*C.float)(unsafe.Pointer(&scaleX))
 	_scaleY := (*C.float)(unsafe.Pointer(&scaleY))
@@ -385,7 +418,8 @@ func (renderer *Renderer) GetScale() (scaleX, scaleY float32) {
 	return
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_SetRenderDrawColor)
+// SetDrawColor sets the color used for drawing operations (Rect, Line and Clear).
+// (https://wiki.libsdl.org/SDL_SetRenderDrawColor)
 func (renderer *Renderer) SetDrawColor(r, g, b, a uint8) error {
 	_r := C.Uint8(r)
 	_g := C.Uint8(g)
@@ -398,7 +432,7 @@ func (renderer *Renderer) SetDrawColor(r, g, b, a uint8) error {
 	return nil
 }
 
-// Custom variant of SetDrawColor
+// SetDrawColorArray is a custom variant of SetDrawColor.
 func (renderer *Renderer) SetDrawColorArray(bs ...uint8) error {
 	_bs := []C.Uint8{0, 0, 0, 255}
 	for i := 0; i < len(_bs) && i < len(bs); i++ {
@@ -411,7 +445,8 @@ func (renderer *Renderer) SetDrawColorArray(bs ...uint8) error {
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_GetRenderDrawColor)
+// GetDrawColor returns the color used for drawing operations (Rect, Line and Clear).
+// (https://wiki.libsdl.org/SDL_GetRenderDrawColor)
 func (renderer *Renderer) GetDrawColor() (r, g, b, a uint8, err error) {
 	_r := (*C.Uint8)(unsafe.Pointer(&r))
 	_g := (*C.Uint8)(unsafe.Pointer(&g))
@@ -425,7 +460,8 @@ func (renderer *Renderer) GetDrawColor() (r, g, b, a uint8, err error) {
 	return r, g, b, a, nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_SetRenderDrawBlendMode)
+// SetDrawBlendMode sets the blend mode used for drawing operations (Fill and Line).
+// (https://wiki.libsdl.org/SDL_SetRenderDrawBlendMode)
 func (renderer *Renderer) SetDrawBlendMode(bm BlendMode) error {
 	_ret := C.SDL_SetRenderDrawBlendMode(renderer.cptr(), bm.c())
 	if _ret < 0 {
@@ -434,7 +470,8 @@ func (renderer *Renderer) SetDrawBlendMode(bm BlendMode) error {
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_GetRenderDrawBlendMode)
+// GetDrawBlendMode returns the blend mode used for drawing operations.
+// (https://wiki.libsdl.org/SDL_GetRenderDrawBlendMode)
 func (renderer *Renderer) GetDrawBlendMode(bm *BlendMode) error {
 	_ret := C.SDL_GetRenderDrawBlendMode(renderer.cptr(), bm.cptr())
 	if _ret < 0 {
@@ -443,7 +480,8 @@ func (renderer *Renderer) GetDrawBlendMode(bm *BlendMode) error {
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderClear)
+// Clear clears the current rendering target with the drawing color.
+// (https://wiki.libsdl.org/SDL_RenderClear)
 func (renderer *Renderer) Clear() error {
 	_ret := C.SDL_RenderClear(renderer.cptr())
 	if _ret < 0 {
@@ -452,7 +490,8 @@ func (renderer *Renderer) Clear() error {
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderDrawPoint)
+// DrawPoint draws a point on the current rendering target.
+// (https://wiki.libsdl.org/SDL_RenderDrawPoint)
 func (renderer *Renderer) DrawPoint(x, y int) error {
 	_ret := C.SDL_RenderDrawPoint(renderer.cptr(), C.int(x), C.int(y))
 	if _ret < 0 {
@@ -461,7 +500,8 @@ func (renderer *Renderer) DrawPoint(x, y int) error {
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderDrawPoints)
+// DrawPoints draws multiple points on the current rendering target.
+// (https://wiki.libsdl.org/SDL_RenderDrawPoints)
 func (renderer *Renderer) DrawPoints(points []Point) error {
 	_ret := C.SDL_RenderDrawPoints(renderer.cptr(), points[0].cptr(), C.int(len(points)))
 	if _ret < 0 {
@@ -470,7 +510,8 @@ func (renderer *Renderer) DrawPoints(points []Point) error {
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderDrawLine)
+// DrawLine draws a line on the current rendering target.
+// (https://wiki.libsdl.org/SDL_RenderDrawLine)
 func (renderer *Renderer) DrawLine(x1, y1, x2, y2 int) error {
 	_x1 := C.int(x1)
 	_y1 := C.int(y1)
@@ -483,7 +524,8 @@ func (renderer *Renderer) DrawLine(x1, y1, x2, y2 int) error {
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderDrawLines)
+// DrawLines draws a series of connected lines on the current rendering target.
+// (https://wiki.libsdl.org/SDL_RenderDrawLines)
 func (renderer *Renderer) DrawLines(points []Point) error {
 	_ret := C.SDL_RenderDrawLines(renderer.cptr(), points[0].cptr(), C.int(len(points)))
 	if _ret < 0 {
@@ -492,7 +534,8 @@ func (renderer *Renderer) DrawLines(points []Point) error {
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderDrawRect)
+// DrawRect draws a rectangle on the current rendering target.
+// (https://wiki.libsdl.org/SDL_RenderDrawRect)
 func (renderer *Renderer) DrawRect(rect *Rect) error {
 	_ret := C.SDL_RenderDrawRect(renderer.cptr(), rect.cptr())
 	if _ret < 0 {
@@ -501,7 +544,8 @@ func (renderer *Renderer) DrawRect(rect *Rect) error {
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderDrawRects)
+// DrawRects draws some number of rectangles on the current rendering target.
+// (https://wiki.libsdl.org/SDL_RenderDrawRects)
 func (renderer *Renderer) DrawRects(rects []Rect) error {
 	_ret := C.SDL_RenderDrawRects(renderer.cptr(), rects[0].cptr(), C.int(len(rects)))
 	if _ret < 0 {
@@ -510,7 +554,8 @@ func (renderer *Renderer) DrawRects(rects []Rect) error {
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderFillRect)
+// FillRect fills a rectangle on the current rendering target with the drawing color.
+// (https://wiki.libsdl.org/SDL_RenderFillRect)
 func (renderer *Renderer) FillRect(rect *Rect) error {
 	_ret := C.SDL_RenderFillRect(renderer.cptr(), rect.cptr())
 	if _ret < 0 {
@@ -519,7 +564,8 @@ func (renderer *Renderer) FillRect(rect *Rect) error {
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderFillRects)
+// FillRects fills some number of rectangles on the current rendering target with the drawing color.
+// (https://wiki.libsdl.org/SDL_RenderFillRects)
 func (renderer *Renderer) FillRects(rects []Rect) error {
 	_ret := C.SDL_RenderFillRects(renderer.cptr(), rects[0].cptr(), C.int(len(rects)))
 	if _ret < 0 {
@@ -528,7 +574,8 @@ func (renderer *Renderer) FillRects(rects []Rect) error {
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderCopy)
+// Copy copies a portion of the texture to the current rendering target.
+// (https://wiki.libsdl.org/SDL_RenderCopy)
 func (renderer *Renderer) Copy(texture *Texture, src, dst *Rect) error {
 	_ret := C.SDL_RenderCopy(renderer.cptr(), texture.cptr(), src.cptr(), dst.cptr())
 	if _ret < 0 {
@@ -537,7 +584,8 @@ func (renderer *Renderer) Copy(texture *Texture, src, dst *Rect) error {
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderCopyEx)
+// CopyEx copies a portion of the texture to the current rendering target, optionally rotating it by angle around the given center and also flipping it top-bottom and/or left-right.
+// (https://wiki.libsdl.org/SDL_RenderCopyEx)
 func (renderer *Renderer) CopyEx(texture *Texture, src, dst *Rect, angle float64, center *Point, flip RendererFlip) error {
 	_ret := C.SDL_RenderCopyEx(renderer.cptr(), texture.cptr(), src.cptr(), dst.cptr(), C.double(angle), center.cptr(), flip.c())
 	if _ret < 0 {
@@ -546,7 +594,8 @@ func (renderer *Renderer) CopyEx(texture *Texture, src, dst *Rect, angle float64
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderReadPixels)
+// ReadPixels reads pixels from the current rendering target.
+// (https://wiki.libsdl.org/SDL_RenderReadPixels)
 func (renderer *Renderer) ReadPixels(rect *Rect, format uint32, pixels unsafe.Pointer, pitch int) error {
 	_ret := C.SDL_RenderReadPixels(renderer.cptr(), rect.cptr(), C.Uint32(format), pixels, C.int(pitch))
 	if _ret < 0 {
@@ -555,22 +604,26 @@ func (renderer *Renderer) ReadPixels(rect *Rect, format uint32, pixels unsafe.Po
 	return nil
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_RenderPresent)
+// Present updates the screen with any rendering performed since the previous call.
+// (https://wiki.libsdl.org/SDL_RenderPresent)
 func (renderer *Renderer) Present() {
 	C.SDL_RenderPresent(renderer.cptr())
 }
 
-// Texture (https://wiki.libsdl.org/SDL_DestroyTexture)
+// Destroy destroys the specified texture.
+// (https://wiki.libsdl.org/SDL_DestroyTexture)
 func (texture *Texture) Destroy() {
 	C.SDL_DestroyTexture(texture.cptr())
 }
 
-// Renderer (https://wiki.libsdl.org/SDL_DestroyRenderer)
+// Destroy destroys the rendering context for a window and free associated textures.
+// (https://wiki.libsdl.org/SDL_DestroyRenderer)
 func (renderer *Renderer) Destroy() {
 	C.SDL_DestroyRenderer(renderer.cptr())
 }
 
-// Texture (https://wiki.libsdl.org/SDL_GL_BindTexture)
+// GLBind binds an OpenGL/ES/ES2 texture to the current context for use with OpenGL instructions when rendering OpenGL primitives directly.
+// (https://wiki.libsdl.org/SDL_GL_BindTexture)
 func (texture *Texture) GLBind(texw, texh *float32) error {
 	_texw := (*C.float)(unsafe.Pointer(texw))
 	_texh := (*C.float)(unsafe.Pointer(texh))
@@ -581,7 +634,8 @@ func (texture *Texture) GLBind(texw, texh *float32) error {
 	return nil
 }
 
-// Texture (https://wiki.libsdl.org/SDL_GL_UnbindTexture)
+// GLUnbind unbinds an OpenGL/ES/ES2 texture from the current context.
+// (https://wiki.libsdl.org/SDL_GL_UnbindTexture)
 func (texture *Texture) GLUnbind() error {
 	_ret := C.SDL_GL_UnbindTexture(texture.cptr())
 	if _ret < 0 {

--- a/sdl/render.go
+++ b/sdl/render.go
@@ -16,31 +16,43 @@ import "C"
 import "reflect"
 import "unsafe"
 
+// An enumeration of flags used when creating a rendering context.
+// (https://wiki.libsdl.org/SDL_RendererFlags)
 const (
-	RENDERER_SOFTWARE      = C.SDL_RENDERER_SOFTWARE
-	RENDERER_ACCELERATED   = C.SDL_RENDERER_ACCELERATED
-	RENDERER_PRESENTVSYNC  = C.SDL_RENDERER_PRESENTVSYNC
-	RENDERER_TARGETTEXTURE = C.SDL_RENDERER_TARGETTEXTURE
-
-	TEXTUREACCESS_STATIC    = C.SDL_TEXTUREACCESS_STATIC
-	TEXTUREACCESS_STREAMING = C.SDL_TEXTUREACCESS_STREAMING
-	TEXTUREACCESS_TARGET    = C.SDL_TEXTUREACCESS_TARGET
-
-	TEXTUREMODULATE_NONE  = C.SDL_TEXTUREMODULATE_NONE
-	TEXTUREMODULATE_COLOR = C.SDL_TEXTUREMODULATE_COLOR
-	TEXTUREMODULATE_ALPHA = C.SDL_TEXTUREMODULATE_ALPHA
+	RENDERER_SOFTWARE      = C.SDL_RENDERER_SOFTWARE      // the renderer is a software fallback
+	RENDERER_ACCELERATED   = C.SDL_RENDERER_ACCELERATED   // the renderer uses hardware acceleration
+	RENDERER_PRESENTVSYNC  = C.SDL_RENDERER_PRESENTVSYNC  // present is synchronized with the refresh rate
+	RENDERER_TARGETTEXTURE = C.SDL_RENDERER_TARGETTEXTURE // the renderer supports rendering to texture
 )
 
+// An enumeration of texture access patterns..
+// (https://wiki.libsdl.org/SDL_TextureAccess)
 const (
-	FLIP_NONE       RendererFlip = C.SDL_FLIP_NONE
-	FLIP_HORIZONTAL              = C.SDL_FLIP_HORIZONTAL
-	FLIP_VERTICAL                = C.SDL_FLIP_VERTICAL
+	TEXTUREACCESS_STATIC    = C.SDL_TEXTUREACCESS_STATIC    // changes rarely, not lockable
+	TEXTUREACCESS_STREAMING = C.SDL_TEXTUREACCESS_STREAMING // changes frequently, lockable
+	TEXTUREACCESS_TARGET    = C.SDL_TEXTUREACCESS_TARGET    // can be used as a render target
+)
+
+// An enumeration of the texture channel modulation used in Renderer.Copy().
+// (https://wiki.libsdl.org/SDL_TextureModulate)
+const (
+	TEXTUREMODULATE_NONE  = C.SDL_TEXTUREMODULATE_NONE  // no modulation
+	TEXTUREMODULATE_COLOR = C.SDL_TEXTUREMODULATE_COLOR // srcC = srcC * color
+	TEXTUREMODULATE_ALPHA = C.SDL_TEXTUREMODULATE_ALPHA // srcA = srcA * alpha
+)
+
+// An enumeration of flags that can be used in the flip parameter for Renderer.CopyEx().
+// (https://wiki.libsdl.org/SDL_RendererFlip)
+const (
+	FLIP_NONE       RendererFlip = C.SDL_FLIP_NONE       // do not flip
+	FLIP_HORIZONTAL              = C.SDL_FLIP_HORIZONTAL // flip horizontally
+	FLIP_VERTICAL                = C.SDL_FLIP_VERTICAL   // flip vertically
 )
 
 // RendererInfo contains information on the capabilities of a render driver or the current render context.
 // (https://wiki.libsdl.org/SDL_RendererInfo)
 type RendererInfo struct {
-	Name string
+	Name string // the name of the renderer
 	RendererInfoData
 }
 
@@ -49,12 +61,14 @@ type cRendererInfo struct {
 	RendererInfoData
 }
 
+// RendererInfoData contains information on the capabilities of a render driver or the current render context.
+// (https://wiki.libsdl.org/SDL_RendererInfo)
 type RendererInfoData struct {
-	Flags             uint32
-	NumTextureFormats uint32
-	TextureFormats    [16]int32
-	MaxTextureWidth   int32
-	MaxTextureHeight  int32
+	Flags             uint32    // a mask of supported renderer flags
+	NumTextureFormats uint32    // the number of available texture formats
+	TextureFormats    [16]int32 // the available texture formats
+	MaxTextureWidth   int32     // the maximum texture width
+	MaxTextureHeight  int32     // the maximum texture height
 }
 
 func (info *RendererInfo) cptr() *C.SDL_RendererInfo {

--- a/sdl/render.go
+++ b/sdl/render.go
@@ -356,7 +356,7 @@ func (renderer *Renderer) SetLogicalSize(w int, h int) error {
 	return nil
 }
 
-// GetLogicalSize Use returns device independent resolution for rendering.
+// GetLogicalSize returns device independent resolution for rendering.
 // (https://wiki.libsdl.org/SDL_RenderGetLogicalSize)
 func (renderer *Renderer) GetLogicalSize() (w, h int) {
 	_w := (*C.int)(unsafe.Pointer(&w))

--- a/sdl/render.go
+++ b/sdl/render.go
@@ -5,9 +5,9 @@ package sdl
 
 #if !(SDL_VERSION_ATLEAST(2,0,1))
 #pragma message("SDL_UpdateYUVTexture is not supported before SDL 2.0.1")
-static inline char* SDL_UpdateYUVTexture()
+static inline char* SDL_UpdateYUVTexture(SDL_Texture* texture, const SDL_Rect* rect, const Uint8* Yplane, int Ypitch, const Uint8* Uplane, int Upitch, const Uint8* Vplane, int Vpitch)
 {
-	return NULL;
+	return -1;
 }
 #endif
 


### PR DESCRIPTION
Added documentation for audio.go and some leftovers in render.go.

## There are some breaking changes this time:

1. Renamed **Padding** to **padding** in AudioSpec struct. Don't think that it should be exported.
```go
type AudioSpec struct {
	padding  uint16         // necessary for some compile environments (internal use)
}
```
2.  Renamed LoadWAV_RW() to LoadWAVRW(). Golang naming convention is:

> Names in Go should use MixedCase.
> (Don't use names_with_underscores.)
> Acronyms should be all capitals, as in ServeHTTP and IDProcessor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/veandco/go-sdl2/268)
<!-- Reviewable:end -->
