### PR TITLE
Move gl init call

### DIFF
--- a/examples/opengl/opengl.go
+++ b/examples/opengl/opengl.go
@@ -22,10 +22,6 @@ func main() {
 	}
 	defer sdl.Quit()
 
-	if err = gl.Init(); err != nil {
-		panic(err)
-	}
-
 	window, err = sdl.CreateWindow(winTitle, sdl.WINDOWPOS_UNDEFINED, sdl.WINDOWPOS_UNDEFINED,
 		winWidth, winHeight, sdl.WINDOW_OPENGL)
 	if err != nil {
@@ -37,6 +33,10 @@ func main() {
 		panic(err)
 	}
 	defer sdl.GLDeleteContext(context)
+
+	if err = gl.Init(); err != nil {
+		panic(err)
+	}
 
 	gl.Enable(gl.DEPTH_TEST)
 	gl.ClearColor(0.2, 0.2, 0.3, 1.0)


### PR DESCRIPTION
GL init call has to be after the context creation.  This example was failing on windows (although it appears to work for other OSes).  Moving init call fixes the windows version.  Based on other readings on the internet, other operating systems should be unaffected

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/veandco/go-sdl2/283)
<!-- Reviewable:end -->
