### PR TITLE
sdl: Fix computation of slice returned by LockTexture.

### DIFF
--- a/sdl/render.go
+++ b/sdl/render.go
@@ -307,7 +307,8 @@ func (texture *Texture) Lock(rect *Rect) ([]byte, int, error) {
 
 	pitch := int32(_pitch)
 	if rect != nil {
-		length = int((pitch / w) * rect.W * rect.H)
+		bytesPerPixel := pitch / w
+		length = int(bytesPerPixel * (w*rect.H - rect.X - (w - rect.X - rect.W)))
 	} else {
 		length = int(pitch * h)
 	}


### PR DESCRIPTION
When SDL_LockTexture is given a rect the pointer that is returned points
to the very first pixel (X:0, Y:0 of the Rect) and contains a valid
memory address for every sub pixel coordinate after that until the final
pixel. This means that a 200x200 square inside of a 400x400 texture
should have a length of 319,200. The pitch and dimensions of the target
locked area should be used to skip over the portions that are unused.

This changes the Lock function to return the full slice of bytes that should
be addressable by the caller of the Lock function. Before this change the slice
returned only had a length of the rectangle dimensions and made it impossible
to fill in the entire locked rectangle.

The algorithm used to compute the length is as follows:
Compute the amount of bytes per pixel by dividing the pitch by the pixel
width. Then compute the number of pixels as though we were using the
entirety of each row in the rectangle. Then subtract out the the unused
leading pixels. Then subtract out the unused trailing pixels.

Some sample code can be found here:
https://gist.github.com/thomas-holmes/0711d7b73e6c893056b66788ba2abdf1
Illustrative images:
https://imgur.com/a/I90GI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/veandco/go-sdl2/291)
<!-- Reviewable:end -->
