### PR TITLE
Fixed text example

### DIFF
--- a/examples/text/text.go
+++ b/examples/text/text.go
@@ -32,24 +32,24 @@ func run() int {
 	defer window.Destroy()
 
 	if font, err = ttf.OpenFont("../../assets/test.ttf", 32); err != nil {
-		fmt.Fprint(os.Stderr, "Failed to open font: %s\n", err)
+		fmt.Fprintf(os.Stderr, "Failed to open font: %s\n", err)
 		return 4
 	}
 	defer font.Close()
 
-	if solid, err = font.RenderUTF8Solid("Hello, World!", sdl.Color{255, 0, 0, 255}); err != nil {
-		fmt.Fprint(os.Stderr, "Failed to render text: %s\n", err)
+	if solid, err = font.RenderUTF8_Solid("Hello, World!", sdl.Color{255, 0, 0, 255}); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to render text: %s\n", err)
 		return 5
 	}
 	defer solid.Free()
 
 	if surface, err = window.GetSurface(); err != nil {
-		fmt.Fprint(os.Stderr, "Failed to get window surface: %s\n", err)
+		fmt.Fprintf(os.Stderr, "Failed to get window surface: %s\n", err)
 		return 6
 	}
 
 	if err = solid.Blit(nil, surface, nil); err != nil {
-		fmt.Fprint(os.Stderr, "Failed to put text on window surface: %s\n", err)
+		fmt.Fprintf(os.Stderr, "Failed to put text on window surface: %s\n", err)
 		return 7
 	}
 


### PR DESCRIPTION
RenderUTF8Solid should be RenderUTF8_Solid

multiple Fprint's changed, assumes original author intended Fprint**f** instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/veandco/go-sdl2/297)
<!-- Reviewable:end -->
