### PR TITLE
README: update the example to work out-of-box on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,23 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	surface.FillRect(nil, 0)
 
 	rect := sdl.Rect{0, 0, 200, 200}
 	surface.FillRect(&rect, 0xffff0000)
 	window.UpdateSurface()
 
-	sdl.Delay(2500)
+	running := true
+	for running {
+		for event := sdl.PollEvent(); event != nil; event = sdl.PollEvent() {
+			switch event.(type) {
+			case *sdl.QuitEvent:
+				println("Quit")
+				running = false
+				break
+			}
+		}
+	}
 }
 ```
 


### PR DESCRIPTION
Minor changes to the example in the readme to work out-of-the box in macOS.

Two parts:

1) without the loop (taken from #262), the window will be stuck in background and reported as "program not responding" by macOS.

2) without the `surface.FillRect(nil, 0)`, the window is not properly cleared.