### PR TITLE
Making go-sdl2 a bit more compatible with Go standard libraries

### DIFF
--- a/raster/painter.go
+++ b/raster/painter.go
@@ -18,7 +18,7 @@ type ImagePainter struct {
 	c     color.Color
 }
 
-// Paints a batch of Spans using the current ImagePainter image and color.
+// Paint a batch of Spans using the current ImagePainter image and color.
 // Image's Color model will be used to convert the color.
 func (p *ImagePainter) Paint(ss []raster.Span, done bool) {
 	// Convert color to RGBA

--- a/raster/painter.go
+++ b/raster/painter.go
@@ -1,3 +1,8 @@
+// This code is inspired to golang/freetype/raster
+
+// Package raster implements a Painter interface for rasterizing paths over
+// a generic Image, using its ColorModel to convert from a generic raster color
+// to the correct color model.
 package raster
 
 import (
@@ -6,11 +11,15 @@ import (
 	"image/draw"
 )
 
+// ImagePainter operates on a generic Image (not only sdl.Surfaces) and allows
+// to rasterize a path using a specific color.
 type ImagePainter struct {
 	Image draw.Image
 	c     color.Color
 }
 
+// Paints a batch of Spans using the current ImagePainter image and color.
+// Image's Color model will be used to convert the color.
 func (p *ImagePainter) Paint(ss []raster.Span, done bool) {
 	// Convert color to RGBA
 	dr, dg, db, da := p.c.RGBA() // 16 bit values
@@ -37,7 +46,7 @@ func (p *ImagePainter) Paint(ss []raster.Span, done bool) {
 			// Get destination pixel color in RGBA64
 			sr, sg, sb, sa := p.Image.At(x, y).RGBA() // 16 bit values
 			// Compute destination color in RGBA64
-			var a uint32 = (m - (da * ma / m))
+			var a uint32 = (mask - (da * ma / m))
 			rr := uint16((dr*ma + sr*a) / m)
 			gg := uint16((dg*ma + sg*a) / m)
 			bb := uint16((db*ma + sb*a) / m)
@@ -48,10 +57,12 @@ func (p *ImagePainter) Paint(ss []raster.Span, done bool) {
 	}
 }
 
+// Set the color to use when rasterizing
 func (p *ImagePainter) SetColor(c color.Color) {
 	p.c = c
 }
 
+// Builds a Painter for a specific Image
 func NewImagePainter(m draw.Image) *ImagePainter {
 	return &ImagePainter{Image: m}
 }

--- a/raster/painter.go
+++ b/raster/painter.go
@@ -1,0 +1,57 @@
+package raster
+
+import (
+	"github.com/golang/freetype/raster"
+	"image/color"
+	"image/draw"
+)
+
+type ImagePainter struct {
+	Image draw.Image
+	c     color.Color
+}
+
+func (p *ImagePainter) Paint(ss []raster.Span, done bool) {
+	// Convert color to RGBA
+	dr, dg, db, da := p.c.RGBA() // 16 bit values
+	// Alpha mask
+	const m = 1<<16 - 1
+	// Draw spans
+	b := p.Image.Bounds()
+	for _, s := range ss {
+		if s.Y < b.Min.Y || s.Y >= b.Max.Y {
+			continue
+		}
+		if s.X0 < b.Min.X {
+			s.X0 = b.Min.X
+		}
+		if s.X1 > b.Max.X {
+			s.X1 = b.Max.X
+		}
+		if s.X0 >= s.X1 {
+			continue
+		}
+		for x := s.X0; x < s.X1; x++ {
+			y := s.Y - b.Min.Y
+			var ma uint32 = s.Alpha // 16 bit value
+			// Get destination pixel color in RGBA64
+			sr, sg, sb, sa := p.Image.At(x, y).RGBA() // 16 bit values
+			// Compute destination color in RGBA64
+			var a uint32 = (m - (da * ma / m))
+			rr := uint16((dr*ma + sr*a) / m)
+			gg := uint16((dg*ma + sg*a) / m)
+			bb := uint16((db*ma + sb*a) / m)
+			aa := uint16((da*ma + sa*a) / m)
+			// Use image model to convert
+			p.Image.Set(x, y, color.RGBA64{rr, gg, bb, aa})
+		}
+	}
+}
+
+func (p *ImagePainter) SetColor(c color.Color) {
+	p.c = c
+}
+
+func NewImagePainter(m draw.Image) *ImagePainter {
+	return &ImagePainter{Image: m}
+}

--- a/raster/painter.go
+++ b/raster/painter.go
@@ -46,7 +46,7 @@ func (p *ImagePainter) Paint(ss []raster.Span, done bool) {
 			// Get destination pixel color in RGBA64
 			sr, sg, sb, sa := p.Image.At(x, y).RGBA() // 16 bit values
 			// Compute destination color in RGBA64
-			var a uint32 = (mask - (da * ma / m))
+			var a uint32 = (m - (da * ma / m))
 			rr := uint16((dr*ma + sr*a) / m)
 			gg := uint16((dg*ma + sg*a) / m)
 			bb := uint16((db*ma + sb*a) / m)

--- a/raster/painter.go
+++ b/raster/painter.go
@@ -46,7 +46,7 @@ func (p *ImagePainter) Paint(ss []raster.Span, done bool) {
 			// Get destination pixel color in RGBA64
 			sr, sg, sb, sa := p.Image.At(x, y).RGBA() // 16 bit values
 			// Compute destination color in RGBA64
-			var a uint32 = (m - (da * ma / m))
+			var a = (m - (da * ma / m))
 			rr := uint16((dr*ma + sr*a) / m)
 			gg := uint16((dg*ma + sg*a) / m)
 			bb := uint16((db*ma + sb*a) / m)
@@ -57,12 +57,12 @@ func (p *ImagePainter) Paint(ss []raster.Span, done bool) {
 	}
 }
 
-// Set the color to use when rasterizing
+// SetColor set the color to use when rasterizing
 func (p *ImagePainter) SetColor(c color.Color) {
 	p.c = c
 }
 
-// Builds a Painter for a specific Image
+// NewImagePainter builds a Painter for a generic Image
 func NewImagePainter(m draw.Image) *ImagePainter {
 	return &ImagePainter{Image: m}
 }

--- a/raster/painter_test.go
+++ b/raster/painter_test.go
@@ -44,5 +44,4 @@ func TestImagePainter(t *testing.T) {
 	if err := f.Close(); err != nil {
 		t.Error(err)
 	}
-	t.Error("Done")
 }

--- a/raster/painter_test.go
+++ b/raster/painter_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestImagePainter(t *testing.T) {
+	// Spans to render
 	ss := []raster.Span{
 		raster.Span{0, 4, 6, 0xffff},
 		raster.Span{1, 3, 7, 0xf0f0},
@@ -21,18 +22,11 @@ func TestImagePainter(t *testing.T) {
 	}
 
 	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
-	/*
-		for i := 0; i < 10; i++ {
-			for j := 0; j < 10; j++ {
-				img.SetRGBA(i, j, color.RGBA{0x00, 0x00, 0x00, 0xff})
-			}
-		}
-	*/
 	pt := NewImagePainter(img)
 	pt.SetColor(color.RGBA{0xff, 0x00, 0x00, 0xff})
 	pt.Paint(ss, false)
+
 	// Write to PNG
-	print("CREATING")
 	f, err := os.Create("output.png")
 	if err != nil {
 		t.Error(err)

--- a/raster/painter_test.go
+++ b/raster/painter_test.go
@@ -1,0 +1,48 @@
+package raster
+
+import (
+	"testing"
+
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+
+	"github.com/golang/freetype/raster"
+)
+
+func TestImagePainter(t *testing.T) {
+	ss := []raster.Span{
+		raster.Span{0, 4, 6, 0xffff},
+		raster.Span{1, 3, 7, 0xf0f0},
+		raster.Span{2, 2, 8, 0x8f8f},
+		raster.Span{3, 1, 9, 0x8080},
+		raster.Span{4, 0, 10, 0x0f0f},
+	}
+
+	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
+	/*
+		for i := 0; i < 10; i++ {
+			for j := 0; j < 10; j++ {
+				img.SetRGBA(i, j, color.RGBA{0x00, 0x00, 0x00, 0xff})
+			}
+		}
+	*/
+	pt := NewImagePainter(img)
+	pt.SetColor(color.RGBA{0xff, 0x00, 0x00, 0xff})
+	pt.Paint(ss, false)
+	// Write to PNG
+	print("CREATING")
+	f, err := os.Create("output.png")
+	if err != nil {
+		t.Error(err)
+	}
+	if err := png.Encode(f, img); err != nil {
+		f.Close()
+		t.Error(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Error(err)
+	}
+	t.Error("Done")
+}

--- a/sdl/pixels.go
+++ b/sdl/pixels.go
@@ -3,6 +3,7 @@ package sdl
 // #include "sdl_wrapper.h"
 import "C"
 import "unsafe"
+import "image/color"
 
 // PixelFormat contains pixel format information.
 // (https://wiki.libsdl.org/SDL_PixelFormat)
@@ -39,14 +40,9 @@ type Palette struct {
 }
 type cPalette C.SDL_Palette
 
-// Color represents a color.
+// Color represents a color. This implements image/color.Color interface.
 // (https://wiki.libsdl.org/SDL_Color)
-type Color struct {
-	R uint8 // the red component in the range 0-255
-	G uint8 // the green component in the range 0-255
-	B uint8 // the blue component in the range 0-255
-	A uint8 // the alpha component in the range 0-255
-}
+type Color color.RGBA
 
 // Uint32 return uint32 representation of RGBA color.
 func (c Color) Uint32() uint32 {
@@ -56,25 +52,6 @@ func (c Color) Uint32() uint32 {
 	v |= uint32(c.G) << 8
 	v |= uint32(c.B)
 	return v
-}
-
-// RGBA returns the alpha-premultiplied red, green, blue and alpha values
-// for the color. Each value ranges within [0, 0xffff], but is represented
-// by a uint32 so that multiplying by a blend factor up to 0xffff will not
-// overflow.
-//
-// An alpha-premultiplied color component c has been scaled by alpha (a),
-// so has valid values 0 <= c <= a.
-func (c Color) RGBA() (r, g, b, a uint32) {
-	r = uint32(c.R)
-	r |= r << 8
-	g = uint32(c.G)
-	g |= g << 8
-	b = uint32(c.B)
-	b |= b << 8
-	a = uint32(c.A)
-	a |= a << 8
-	return
 }
 
 // Pixel types.

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -524,6 +524,7 @@ func (surface *Surface) Duplicate() (newSurface *Surface, err error) {
 	return
 }
 
+// Return the color model used by this Surface.
 func (s *Surface) ColorModel() color.Model {
 	switch s.Format.Format {
 	case PIXELFORMAT_ARGB8888, PIXELFORMAT_ABGR8888:
@@ -535,10 +536,13 @@ func (s *Surface) ColorModel() color.Model {
 	}
 }
 
+// Return the bounds of this surface. Currently, it always starts at (0,0), but
+// this is not guaranteed in the future so don't rely on it.
 func (s *Surface) Bounds() image.Rectangle {
 	return image.Rect(0, 0, int(s.W), int(s.H))
 }
 
+// Return the pixel color at (x, y)
 func (s *Surface) At(x, y int) color.Color {
 	pix := s.Pixels()
 	i := int32(y)*s.Pitch + int32(x)*int32(s.Format.BytesPerPixel)
@@ -556,6 +560,9 @@ func (s *Surface) At(x, y int) color.Color {
 	}
 }
 
+// Set the color of the pixel at (x, y) using this surface's color model to
+// convert c to the appropriate color. This method is required for the
+// draw.Image interface. The surface may require locking before calling Set.
 func (s *Surface) Set(x, y int, c color.Color) {
 	pix := s.Pixels()
 	i := int32(y)*s.Pitch + int32(x)*int32(s.Format.BytesPerPixel)

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -78,6 +78,8 @@ static inline SDL_Surface* SDL_CreateRGBSurfaceWithFormatFrom(void* pixels, int 
 import "C"
 import "unsafe"
 import "reflect"
+import "image"
+import "image/color"
 
 // Surface flags (internal use)
 const (
@@ -520,4 +522,67 @@ func (surface *Surface) Duplicate() (newSurface *Surface, err error) {
 
 	newSurface = (*Surface)(unsafe.Pointer(_newSurface))
 	return
+}
+
+func (s *Surface) ColorModel() color.Model {
+	switch s.Format.Format {
+	case PIXELFORMAT_ARGB8888, PIXELFORMAT_ABGR8888:
+		return color.RGBAModel
+	case PIXELFORMAT_RGB888:
+		return color.RGBAModel
+	default:
+		panic("Not implemented yet")
+	}
+}
+
+func (s *Surface) Bounds() image.Rectangle {
+	return image.Rect(0, 0, int(s.W), int(s.H))
+}
+
+func (s *Surface) At(x, y int) color.Color {
+	pix := s.Pixels()
+	i := int32(y)*s.Pitch + int32(x)*int32(s.Format.BytesPerPixel)
+	switch s.Format.Format {
+	/*
+		case PIXELFORMAT_ARGB8888:
+			return color.RGBA{pix[i+3], pix[i], pix[i+1], pix[i+2]}
+		case PIXELFORMAT_ABGR8888:
+			return color.RGBA{pix[i], pix[i+3], pix[i+2], pix[i+1]}
+	*/
+	case PIXELFORMAT_RGB888:
+		return color.RGBA{pix[i], pix[i+1], pix[i+2], 0xff}
+	default:
+		panic("Not implemented yet")
+	}
+}
+
+func (s *Surface) Set(x, y int, c color.Color) {
+	pix := s.Pixels()
+	i := int32(y)*s.Pitch + int32(x)*int32(s.Format.BytesPerPixel)
+	switch s.Format.Format {
+	case PIXELFORMAT_ARGB8888:
+		col := s.ColorModel().Convert(c).(color.RGBA)
+		pix[i+0] = col.R
+		pix[i+1] = col.G
+		pix[i+2] = col.B
+		pix[i+3] = col.A
+	case PIXELFORMAT_ABGR8888:
+		col := s.ColorModel().Convert(c).(color.RGBA)
+		pix[i+3] = col.R
+		pix[i+2] = col.G
+		pix[i+1] = col.B
+		pix[i+0] = col.A
+	case PIXELFORMAT_RGB24, PIXELFORMAT_RGB888:
+		col := s.ColorModel().Convert(c).(color.RGBA)
+		pix[i+0] = col.B
+		pix[i+1] = col.G
+		pix[i+2] = col.R
+	case PIXELFORMAT_BGR24, PIXELFORMAT_BGR888:
+		col := s.ColorModel().Convert(c).(color.RGBA)
+		pix[i+2] = col.R
+		pix[i+1] = col.G
+		pix[i+0] = col.B
+	default:
+		panic("Unknown pixel format!")
+	}
 }

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -524,9 +524,9 @@ func (surface *Surface) Duplicate() (newSurface *Surface, err error) {
 	return
 }
 
-// Return the color model used by this Surface.
-func (s *Surface) ColorModel() color.Model {
-	switch s.Format.Format {
+// ColorModel returns the color model used by this Surface.
+func (surface *Surface) ColorModel() color.Model {
+	switch surface.Format.Format {
 	case PIXELFORMAT_ARGB8888, PIXELFORMAT_ABGR8888:
 		return color.RGBAModel
 	case PIXELFORMAT_RGB888:
@@ -536,17 +536,17 @@ func (s *Surface) ColorModel() color.Model {
 	}
 }
 
-// Return the bounds of this surface. Currently, it always starts at (0,0), but
-// this is not guaranteed in the future so don't rely on it.
-func (s *Surface) Bounds() image.Rectangle {
-	return image.Rect(0, 0, int(s.W), int(s.H))
+// Bounds return the bounds of this surface. Currently, it always starts at
+// (0,0), but this is not guaranteed in the future so don't rely on it.
+func (surface *Surface) Bounds() image.Rectangle {
+	return image.Rect(0, 0, int(surface.W), int(surface.H))
 }
 
-// Return the pixel color at (x, y)
-func (s *Surface) At(x, y int) color.Color {
-	pix := s.Pixels()
-	i := int32(y)*s.Pitch + int32(x)*int32(s.Format.BytesPerPixel)
-	switch s.Format.Format {
+// At returns the pixel color at (x, y)
+func (surface *Surface) At(x, y int) color.Color {
+	pix := surface.Pixels()
+	i := int32(y)*surface.Pitch + int32(x)*int32(surface.Format.BytesPerPixel)
+	switch surface.Format.Format {
 	/*
 		case PIXELFORMAT_ARGB8888:
 			return color.RGBA{pix[i+3], pix[i], pix[i+1], pix[i+2]}
@@ -563,29 +563,29 @@ func (s *Surface) At(x, y int) color.Color {
 // Set the color of the pixel at (x, y) using this surface's color model to
 // convert c to the appropriate color. This method is required for the
 // draw.Image interface. The surface may require locking before calling Set.
-func (s *Surface) Set(x, y int, c color.Color) {
-	pix := s.Pixels()
-	i := int32(y)*s.Pitch + int32(x)*int32(s.Format.BytesPerPixel)
-	switch s.Format.Format {
+func (surface *Surface) Set(x, y int, c color.Color) {
+	pix := surface.Pixels()
+	i := int32(y)*surface.Pitch + int32(x)*int32(surface.Format.BytesPerPixel)
+	switch surface.Format.Format {
 	case PIXELFORMAT_ARGB8888:
-		col := s.ColorModel().Convert(c).(color.RGBA)
+		col := surface.ColorModel().Convert(c).(color.RGBA)
 		pix[i+0] = col.R
 		pix[i+1] = col.G
 		pix[i+2] = col.B
 		pix[i+3] = col.A
 	case PIXELFORMAT_ABGR8888:
-		col := s.ColorModel().Convert(c).(color.RGBA)
+		col := surface.ColorModel().Convert(c).(color.RGBA)
 		pix[i+3] = col.R
 		pix[i+2] = col.G
 		pix[i+1] = col.B
 		pix[i+0] = col.A
 	case PIXELFORMAT_RGB24, PIXELFORMAT_RGB888:
-		col := s.ColorModel().Convert(c).(color.RGBA)
+		col := surface.ColorModel().Convert(c).(color.RGBA)
 		pix[i+0] = col.B
 		pix[i+1] = col.G
 		pix[i+2] = col.R
 	case PIXELFORMAT_BGR24, PIXELFORMAT_BGR888:
-		col := s.ColorModel().Convert(c).(color.RGBA)
+		col := surface.ColorModel().Convert(c).(color.RGBA)
 		pix[i+2] = col.R
 		pix[i+1] = col.G
 		pix[i+0] = col.B


### PR DESCRIPTION
This PR does 3 things:

 - changes sdl.Color to image/color.RGBA, which is alpha-premultiplied 32 bit RGBA color; this makes sdl.Color compatible with color.Color.
 - makes sdl.Surface compatible with image.Image and draw.Image, adding few methods that can be used to retrieve the surface color model and get/set pixels at a specified position.
 - introduces a raster subdirectory with an implementation of a [freetype painter](https://github.com/golang/freetype/tree/master/raster) that should work on any Image (therefore, also sdl.Surfaces). This allows to 3rd party packages to draw over sdl.Surface if they make use of freetype painters (e.g. [llgcode/draw2d](https://github.com/llgcode/draw2d)).

This should not break anything, but since sdl.Color changed, more testing on this should be performed.