### PR TITLE
ttf: added MacOS include for sdl_ttf_wrapper.h

### DIFF
--- a/ttf/sdl_ttf_wrapper.h
+++ b/ttf/sdl_ttf_wrapper.h
@@ -1,6 +1,8 @@
 #if defined(__WIN32)
 	#include <SDL2/SDL_ttf.h>
 	#include <stdlib.h>
+#elif defined(__APPLE__)
+	#include <SDL2/SDL_ttf.h>
 #else
 	#include <SDL_ttf.h>
 #endif


### PR DESCRIPTION
On MacOS I am getting
```
./sdl_ttf_wrapper.h:5:11: fatal error: 'SDL_ttf.h' file not found
        #include <SDL_ttf.h>
                 ^~~~~~~~~~~
```

I have `sdl2_ttf` installed through `brew`, and that header is symlinked to `/usr/local/include/SDL2/SDL_ttf.h`.

This PR adds a directive to account for that.