### PR TITLE
Simplify use of MessageBoxData

### DIFF
--- a/sdl/video.go
+++ b/sdl/video.go
@@ -342,13 +342,12 @@ type MessageBoxButtonData struct {
 // MessageBoxData contains title, text, window and other data for a message box.
 // (https://wiki.libsdl.org/SDL_MessageBoxData)
 type MessageBoxData struct {
-	Flags       uint32                 // MESSAGEBOX_ERROR, MESSAGEBOX_WARNING, MESSAGEBOX_INFORMATION
-	Window      *Window                // an parent window, can be nil
-	Title       string                 // an UTF-8 title
-	Message     string                 // an UTF-8 message text
-	NumButtons  int32                  // the number of buttons
-	Buttons     []MessageBoxButtonData // an array of MessageBoxButtonData with size of numbuttons
-	ColorScheme *MessageBoxColorScheme // a MessageBoxColorScheme, can be nil to use system settings
+	Flags       uint32  // MESSAGEBOX_ERROR, MESSAGEBOX_WARNING, MESSAGEBOX_INFORMATION
+	Window      *Window // parent window or nil
+	Title       string
+	Message     string
+	Buttons     []MessageBoxButtonData
+	ColorScheme *MessageBoxColorScheme // nil to use system settings
 }
 
 func (window *Window) cptr() *C.SDL_Window {
@@ -863,7 +862,7 @@ func ShowMessageBox(data *MessageBoxData) (buttonid int32, err error) {
 		window:      data.Window.cptr(),
 		title:       _title,
 		message:     _message,
-		numbuttons:  C.int(data.NumButtons),
+		numbuttons:  C.int(len(data.Buttons)),
 		buttons:     buttonPtr,
 		colorScheme: data.ColorScheme.cptr(),
 	}


### PR DESCRIPTION
The C version of MessageBoxData has a button pointer and a button length. In Go we have a slice of buttons and an extra button length which is unnecessary because in Go we know a slice's length. I removed the extra integer. This makes the code easier to use. It is not Go-like to provide the length of a slice separately. This is error-prone.
Additionally I changed the comments around, leaving only the relevant information, removing some noise.