### PR TITLE
sdl: add integer scale bindings for Renderer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -61,5 +61,6 @@ Here's the list of contributors with their respective Github URLs.
 * [Anton Malashin](https://github.com/malashin)
 * [John Perkins](https://github.com/mpath)
 * [jclc](https://github.com/jclc)
+* [flga](https://github.com/flga)
 
 _if anyone is missing, let me know!.. or you can add yourself in :)_

--- a/sdl/render.go
+++ b/sdl/render.go
@@ -23,6 +23,7 @@ static inline int SDL_UpdateYUVTexture(SDL_Texture* texture, const SDL_Rect* rec
 
 static inline int SDL_RenderSetIntegerScale(SDL_Renderer* renderer, SDL_bool enable)
 {
+	SDL_Unsupported();
 	return -1;
 }
 
@@ -32,6 +33,7 @@ static inline int SDL_RenderSetIntegerScale(SDL_Renderer* renderer, SDL_bool ena
 
 static inline SDL_bool SDL_RenderGetIntegerScale(SDL_Renderer* renderer)
 {
+	SDL_Unsupported();
 	return -1;
 }
 #endif
@@ -509,11 +511,10 @@ func (renderer *Renderer) SetIntegerScale(v bool) error {
 //
 // (https://wiki.libsdl.org/SDL_RenderGetIntegerScale)
 func (renderer *Renderer) GetIntegerScale() (bool, error) {
-	var val C.SDL_bool = C.SDL_RenderGetIntegerScale(renderer.cptr())
-	if val == C.SDL_TRUE {
+	if C.SDL_RenderGetIntegerScale(renderer.cptr()) == C.SDL_TRUE {
 		return true, nil
 	}
-	return false, errorFromInt(int(val))
+	return false, GetError()
 }
 
 // SetDrawColor sets the color used for drawing operations (Rect, Line and Clear).

--- a/sdl/render.go
+++ b/sdl/render.go
@@ -511,6 +511,7 @@ func (renderer *Renderer) SetIntegerScale(v bool) error {
 //
 // (https://wiki.libsdl.org/SDL_RenderGetIntegerScale)
 func (renderer *Renderer) GetIntegerScale() (bool, error) {
+	ClearError()
 	if C.SDL_RenderGetIntegerScale(renderer.cptr()) == C.SDL_TRUE {
 		return true, nil
 	}

--- a/sdl/render.go
+++ b/sdl/render.go
@@ -15,6 +15,27 @@ static inline int SDL_UpdateYUVTexture(SDL_Texture* texture, const SDL_Rect* rec
 }
 #endif
 
+#if !(SDL_VERSION_ATLEAST(2,0,5))
+
+#if defined(WARN_OUTDATED)
+#pragma message("SDL_RenderSetIntegerScale is not supported before SDL 2.0.5")
+#endif
+
+static inline int SDL_RenderSetIntegerScale(SDL_Renderer* renderer, SDL_bool enable)
+{
+	return -1;
+}
+
+#if defined(WARN_OUTDATED)
+#pragma message("SDL_RenderGetIntegerScale is not supported before SDL 2.0.5")
+#endif
+
+static inline SDL_bool SDL_RenderGetIntegerScale(SDL_Renderer* renderer)
+{
+	return -1;
+}
+#endif
+
 #if !(SDL_VERSION_ATLEAST(2,0,8))
 
 
@@ -464,6 +485,35 @@ func (renderer *Renderer) GetScale() (scaleX, scaleY float32) {
 		(*C.float)(unsafe.Pointer(&scaleX)),
 		(*C.float)(unsafe.Pointer(&scaleY)))
 	return
+}
+
+// SetIntegerScale sets whether to force integer scales for
+// resolution-independent rendering.
+//
+// This function restricts the logical viewport to integer values - that is,
+// when a resolution is between two multiples of a logical size, the viewport
+// size is rounded down to the lower multiple.
+//
+// (https://wiki.libsdl.org/SDL_RenderSetIntegerScale)
+func (renderer *Renderer) SetIntegerScale(v bool) error {
+	var cv C.SDL_bool = C.SDL_FALSE
+	if v {
+		cv = C.SDL_TRUE
+	}
+
+	return errorFromInt(int(C.SDL_RenderSetIntegerScale(renderer.cptr(), cv)))
+}
+
+// GetIntegerScale reports whether integer scales are forced for
+// resolution-independent rendering.
+//
+// (https://wiki.libsdl.org/SDL_RenderGetIntegerScale)
+func (renderer *Renderer) GetIntegerScale() (bool, error) {
+	var val C.SDL_bool = C.SDL_RenderGetIntegerScale(renderer.cptr())
+	if val == C.SDL_TRUE {
+		return true, nil
+	}
+	return false, errorFromInt(int(val))
 }
 
 // SetDrawColor sets the color used for drawing operations (Rect, Line and Clear).

--- a/sdl/render_test.go
+++ b/sdl/render_test.go
@@ -63,4 +63,27 @@ func TestRenderIntegerScale(t *testing.T) {
 		set(false, t)
 		check(false, t)
 	})
+
+	t.Run("should handle SDL_FALSE return on GetIntegerScale", func(t *testing.T) {
+		_, dummy, err := CreateWindowAndRenderer(50, 50, 0)
+		if err != nil {
+			t.Fatalf("unable to create renderer: %s", err)
+			return
+		}
+
+		if err := dummy.SetIntegerScale(true); err != nil {
+			t.Fatalf("expected call to SetIntegerScale to succeed, got %s", err)
+		}
+		if err := dummy.Destroy(); err != nil {
+			t.Fatalf("expected call to Destroy to succeed, got %s", err)
+		}
+
+		v, err := dummy.GetIntegerScale()
+		if err == nil {
+			t.Fatalf("expected call to GetIntegerScale on ivalid renderer to fail")
+		}
+		if v != false {
+			t.Fatalf("wanted renderer scale to be %v", false)
+		}
+	})
 }

--- a/sdl/render_test.go
+++ b/sdl/render_test.go
@@ -1,11 +1,33 @@
 package sdl
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestRenderIntegerScale(t *testing.T) {
 	_, r, err := CreateWindowAndRenderer(50, 50, 0)
 	if err != nil {
 		t.Fatalf("unable to create renderer: %s", err)
+		return
+	}
+
+	errUnsupported := errors.New("That operation is not supported")
+
+	if !VERSION_ATLEAST(2, 0, 5) {
+		t.Run("GetIntegerScale on versions < 2.0.5 should return unsupported", func(t *testing.T) {
+			_, got := r.GetIntegerScale()
+			if got.Error() != errUnsupported.Error() {
+				t.Fatalf("expected call to GetIntegerScale to fail with %s, got %s", errUnsupported, got)
+			}
+		})
+		t.Run("SetIntegerScale on versions < 2.0.5 should return unsupported", func(t *testing.T) {
+			got := r.SetIntegerScale(false)
+			if got.Error() != errUnsupported.Error() {
+				t.Fatalf("expected call to SetIntegerScale to fail with %s, got %s", errUnsupported, got)
+			}
+		})
+
 		return
 	}
 

--- a/sdl/render_test.go
+++ b/sdl/render_test.go
@@ -1,0 +1,44 @@
+package sdl
+
+import "testing"
+
+func TestRenderIntegerScale(t *testing.T) {
+	_, r, err := CreateWindowAndRenderer(50, 50, 0)
+	if err != nil {
+		t.Fatalf("unable to create renderer: %s", err)
+		return
+	}
+
+	set := func(v bool, t *testing.T) {
+		if err := r.SetIntegerScale(v); err != nil {
+			t.Fatalf("unable to set scale %v: %s", v, err)
+		}
+	}
+	check := func(want bool, t *testing.T) {
+		got, err := r.GetIntegerScale()
+		if err != nil {
+			t.Fatalf("unable to get scale: %s", err)
+		}
+
+		if got != want {
+			t.Fatalf("wanted renderer scale to be %v", want)
+		}
+	}
+
+	t.Run("should start out as false", func(t *testing.T) {
+		check(false, t)
+	})
+
+	t.Run("if set to true should return true", func(t *testing.T) {
+		set(true, t)
+		check(true, t)
+	})
+
+	t.Run("if set to false should return false", func(t *testing.T) {
+		set(true, t)
+		check(true, t)
+
+		set(false, t)
+		check(false, t)
+	})
+}


### PR DESCRIPTION
Add the missing SDL_RenderGetIntegerScale and SDL_RenderSetIntegerScale methods on the Renderer struct.

I'm not aware of an easy way to test using older versions of sdl (since both these functions are >=2.0.5).
Got any tips on how to do that easily?
I'd like to make sure it works as expected on older versions before merge.