### PR TITLE
sdl: Improve pixel fetching api

### DIFF
--- a/sdl/render.go
+++ b/sdl/render.go
@@ -64,6 +64,7 @@ static inline void * SDL_RenderGetMetalCommandEncoder(SDL_Renderer *renderer)
 */
 import "C"
 import (
+	"bytes"
 	"reflect"
 	"unsafe"
 )
@@ -686,6 +687,58 @@ func (renderer *Renderer) ReadPixels(rect *Rect, format uint32, pixels unsafe.Po
 			C.Uint32(format),
 			pixels,
 			C.int(pitch))))
+}
+
+// GetPixels returns the pixel data of the current rendering target.
+// It just wraps ReadPixels in a neater api, as such it has the same implications.
+func (renderer *Renderer) GetPixels(rect *Rect, format uint32) ([]byte, error) {
+	// rect		A pointer to the rectangle to read, or NULL for the entire render target.
+	// format	The desired format of the pixel data, or 0 to use the format of the rendering target
+	// pixels	A pointer to be filled in with the pixel data
+	// pitch	The pitch of the pixels parameter.
+
+	if format == 0 || rect == nil {
+		targetFormat, _, targetWidth, targetHeight, err := renderer.GetRenderTarget().Query()
+		if err != nil {
+			return nil, err
+		}
+
+		if format == 0 {
+			format = targetFormat
+		}
+		if rect == nil {
+			rect = &Rect{
+				W: targetWidth,
+				H: targetHeight,
+			}
+		}
+	}
+
+	bpp := int32(BytesPerPixel(format))
+
+	padding := []byte("overflow detector")
+	paddingLen := int32(len(padding))
+
+	dataLen := rect.W * rect.H * bpp
+	buffer := make([]byte, dataLen+paddingLen)
+
+	for i := int32(0); i < paddingLen; i++ {
+		buffer[dataLen+i] = padding[i]
+	}
+
+	errCode := C.SDL_RenderReadPixels(
+		renderer.cptr(),
+		rect.cptr(),
+		C.Uint32(format),
+		unsafe.Pointer(&buffer[0]),
+		C.int(rect.W*bpp),
+	)
+
+	if !bytes.Equal(buffer[dataLen:], padding) {
+		panic("overflow detected")
+	}
+
+	return buffer[:dataLen], errorFromInt(int(errCode))
 }
 
 // Present updates the screen with any rendering performed since the previous call.

--- a/sdl/render_test.go
+++ b/sdl/render_test.go
@@ -1,7 +1,10 @@
 package sdl
 
 import (
+	"bytes"
 	"errors"
+	"image/color"
+	"reflect"
 	"testing"
 )
 
@@ -86,4 +89,85 @@ func TestRenderIntegerScale(t *testing.T) {
 			t.Fatalf("wanted renderer scale to be %v", false)
 		}
 	})
+}
+
+func TestGetPixels(t *testing.T) {
+	repeat := bytes.Repeat
+	line := func(a []byte, b []byte, len int) []byte {
+		return append(repeat(a, len), repeat(b, len)...)
+	}
+	concat := func(a []byte, b []byte) []byte {
+		return append(a, b...)
+	}
+	rgba := func(c color.RGBA) []byte {
+		return []byte{c.R, c.G, c.B, c.A}
+	}
+	bgra := func(c color.RGBA) []byte {
+		return []byte{c.A, c.R, c.G, c.B}
+	}
+	drawRect := func(renderer *Renderer, rect *Rect, c color.RGBA) {
+		if err := renderer.SetDrawColor(c.R, c.G, c.B, c.A); err != nil {
+			t.Fatalf("unable to set draw color: %s", err)
+		}
+		if err := renderer.FillRect(rect); err != nil {
+			t.Fatalf("unable to fill rect: %s", err)
+		}
+	}
+
+	_, r, err := CreateWindowAndRenderer(50, 50, 0)
+	if err != nil {
+		t.Fatalf("unable to create renderer: %s", err)
+	}
+
+	c1, r1 := color.RGBA{151, 237, 158, 255}, &Rect{X: 0, Y: 0, W: 25, H: 25}
+	c2, r2 := color.RGBA{151, 213, 237, 255}, &Rect{X: 25, Y: 0, W: 25, H: 25}
+	c3, r3 := color.RGBA{224, 151, 237, 255}, &Rect{X: 0, Y: 25, W: 25, H: 25}
+	c4, r4 := color.RGBA{237, 151, 151, 255}, &Rect{X: 25, Y: 25, W: 25, H: 25}
+
+	drawRect(r, r1, c1)
+	drawRect(r, r2, c2)
+	drawRect(r, r3, c3)
+	drawRect(r, r4, c4)
+
+	tests := []struct {
+		name string
+		rect *Rect
+		fmt  uint32
+		want []byte
+	}{
+		{"r1 ABGR8888", r1, PIXELFORMAT_ABGR8888, repeat(rgba(c1), 25*25)},
+		{"r2 ABGR8888", r2, PIXELFORMAT_ABGR8888, repeat(rgba(c2), 25*25)},
+		{"r3 ABGR8888", r3, PIXELFORMAT_ABGR8888, repeat(rgba(c3), 25*25)},
+		{"r4 ABGR8888", r4, PIXELFORMAT_ABGR8888, repeat(rgba(c4), 25*25)},
+
+		{"r1 + r2 ABGR8888", &Rect{X: 0, Y: 0, W: 50, H: 25}, PIXELFORMAT_ABGR8888, repeat(line(rgba(c1), rgba(c2), 25), 25)},
+		{"r3 + r4 ABGR8888", &Rect{X: 0, Y: 25, W: 50, H: 25}, PIXELFORMAT_ABGR8888, repeat(line(rgba(c3), rgba(c4), 25), 25)},
+		{"r1 + r3 ABGR8888", &Rect{X: 0, Y: 0, W: 25, H: 50}, PIXELFORMAT_ABGR8888, concat(repeat(rgba(c1), 25*25), repeat(rgba(c3), 25*25))},
+		{"r2 + r4 ABGR8888", &Rect{X: 25, Y: 0, W: 25, H: 50}, PIXELFORMAT_ABGR8888, concat(repeat(rgba(c2), 25*25), repeat(rgba(c4), 25*25))},
+
+		{"full ABGR8888", &Rect{X: 0, Y: 0, W: 50, H: 50}, PIXELFORMAT_ABGR8888, concat(repeat(line(rgba(c1), rgba(c2), 25), 25), repeat(line(rgba(c3), rgba(c4), 25), 25))},
+
+		{"r1 BGRA8888", r1, PIXELFORMAT_BGRA8888, repeat(bgra(c1), 25*25)},
+		{"r2 BGRA8888", r2, PIXELFORMAT_BGRA8888, repeat(bgra(c2), 25*25)},
+		{"r3 BGRA8888", r3, PIXELFORMAT_BGRA8888, repeat(bgra(c3), 25*25)},
+		{"r4 BGRA8888", r4, PIXELFORMAT_BGRA8888, repeat(bgra(c4), 25*25)},
+
+		{"r1 + r2 ABGR8888", &Rect{X: 0, Y: 0, W: 50, H: 25}, PIXELFORMAT_BGRA8888, repeat(line(bgra(c1), bgra(c2), 25), 25)},
+		{"r3 + r4 ABGR8888", &Rect{X: 0, Y: 25, W: 50, H: 25}, PIXELFORMAT_BGRA8888, repeat(line(bgra(c3), bgra(c4), 25), 25)},
+		{"r1 + r3 ABGR8888", &Rect{X: 0, Y: 0, W: 25, H: 50}, PIXELFORMAT_BGRA8888, concat(repeat(bgra(c1), 25*25), repeat(bgra(c3), 25*25))},
+		{"r2 + r4 ABGR8888", &Rect{X: 25, Y: 0, W: 25, H: 50}, PIXELFORMAT_BGRA8888, concat(repeat(bgra(c2), 25*25), repeat(bgra(c4), 25*25))},
+
+		{"full ABGR8888", &Rect{X: 0, Y: 0, W: 50, H: 50}, PIXELFORMAT_BGRA8888, concat(repeat(line(bgra(c1), bgra(c2), 25), 25), repeat(line(bgra(c3), bgra(c4), 25), 25))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := r.GetPixels(tt.rect, tt.fmt)
+			if err != nil {
+				t.Fatalf("unable to get pixels for r1: %s", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("wanted %v got: %v", tt.want, got)
+			}
+		})
+	}
 }


### PR DESCRIPTION
I think there's two parts to this problem.

1 - do not require the callers to import unsafe in ReadPixels, just take in a slice and assume it's size is correct (easy enough, but I think it would be best to do it separately)
2 - provide a version of this function that does the heavy lifting for the caller (this pr)

I think it's worthwhile keeping the original implementation and just fixing up the unsafe.Pointer.
For one, it's what the actual SDL api looks like, but it also allows the caller to manage his/her buffers.

The basic principle is to take in a rect and a pixel format and fill in the gaps appropriately.
This isn't ready yet, seems to work but it needs more tests, so I'll be marking it as draft for now.
I also need to rethink the testing methodology, this way of creating the expected pixel buffers is unwieldy.