### PR TITLE
Use correct pkg-config package for SDL2_ttf.

### DIFF
--- a/ttf/sdl_ttf_cgo.go
+++ b/ttf/sdl_ttf_cgo.go
@@ -3,6 +3,6 @@
 package ttf
 
 //#cgo windows LDFLAGS: -lSDL2 -lSDL2_ttf
-//#cgo linux freebsd darwin pkg-config: sdl2
+//#cgo linux freebsd darwin pkg-config: SDL2_ttf
 //#cgo linux freebsd darwin LDFLAGS: -lSDL2_ttf
 import "C"


### PR DESCRIPTION
In almost all systems, the header files for SDL2 and SDL2_ttf will live in the same directory, and then this typo is benign.  On some weird systems (I'll be honest: it's [NixOS](https://nixos.org/)), the directories are different, and then we have to get it right.