### PR TITLE
Build syswm_x11.go only if actually using X11

### DIFF
--- a/sdl/syswm_x11.go
+++ b/sdl/syswm_x11.go
@@ -1,4 +1,4 @@
-// +build x11 OR linux
+// +build x11
 
 package sdl
 


### PR DESCRIPTION
This enables using this binding with SDL2's kmsdrm video driver (HW-accelerated drawing without X11; not enabled by default in SDL2, must configure with `--enable-video-kmsdrm`).