### PR TITLE
fixed UserEvent typecast

### DIFF
--- a/sdl/events.go
+++ b/sdl/events.go
@@ -1032,12 +1032,15 @@ func goEvent(cevent *CEvent) Event {
 		return (*RenderEvent)(unsafe.Pointer(cevent))
 	case QUIT:
 		return (*QuitEvent)(unsafe.Pointer(cevent))
-	case USEREVENT:
-		return (*UserEvent)(unsafe.Pointer(cevent))
 	case CLIPBOARDUPDATE:
 		return (*ClipboardEvent)(unsafe.Pointer(cevent))
 	default:
-		return (*CommonEvent)(unsafe.Pointer(cevent))
+		if cevent.Type >= USEREVENT {
+			// all events beyond USEREVENT are UserEvents to be registered with RegisterEvents
+			return (*UserEvent)(unsafe.Pointer(cevent))
+		} else {
+			return (*CommonEvent)(unsafe.Pointer(cevent))
+		}
 	}
 }
 

--- a/sdl/events.go
+++ b/sdl/events.go
@@ -1038,9 +1038,8 @@ func goEvent(cevent *CEvent) Event {
 		if cevent.Type >= USEREVENT {
 			// all events beyond USEREVENT are UserEvents to be registered with RegisterEvents
 			return (*UserEvent)(unsafe.Pointer(cevent))
-		} else {
-			return (*CommonEvent)(unsafe.Pointer(cevent))
 		}
+		return (*CommonEvent)(unsafe.Pointer(cevent))
 	}
 }
 


### PR DESCRIPTION
RegisterEvents() allows multiple events to be registered. They are numbered starting at and going beyond USEREVENT. Therefore, the cast back to Go types ought to cast everything beyond USEREVENT to a Go UserEvent.