### PR TITLE
fix header name for case sensitive file systems

### DIFF
--- a/sdl/syswm_windows.go
+++ b/sdl/syswm_windows.go
@@ -3,7 +3,7 @@
 package sdl
 
 /*
-#include <WinDef.h>
+#include <windef.h>
 */
 import "C"
 import "unsafe"


### PR DESCRIPTION
Fails to compile on Linux due to case sensitive file system. This PR corrects this issue.

```
../go/pkg/mod/github.com/veandco/go-sdl2@v0.3.1-0.20190819015742-0ac831f22fa9/sdl/syswm_windows.go:6:10: fatal error: WinDef.h: No such file or directory
    6 | #include <WinDef.h>
      |          ^~~~~~~~~~
compilation terminated.
```