### PR TITLE
Add openbsd to sdl_cgo.go

### DIFF
--- a/sdl/sdl_cgo.go
+++ b/sdl/sdl_cgo.go
@@ -3,5 +3,5 @@
 package sdl
 
 //#cgo windows LDFLAGS: -lSDL2
-//#cgo linux freebsd darwin pkg-config: sdl2
+//#cgo linux freebsd darwin openbsd pkg-config: sdl2
 import "C"


### PR DESCRIPTION
This pull request makes the bindings build on OpenBSD. Perhaps `!windows` is the better choice, though?