### PR TITLE
Correct Mix_OpenAudioDevice condition

### DIFF
--- a/mix/sdl_mixer.go
+++ b/mix/sdl_mixer.go
@@ -25,7 +25,7 @@ package mix
 //	return (frames * 1000) / freq;
 //}
 //
-//#if !(SDL_VERSION_ATLEAST(2,0,9))
+//#if !(SDL_MIXER_VERSION_ATLEAST(2,0,2))
 //
 //#if defined(WARN_OUTDATED)
 //#pragma message("Mix_OpenAudioDevice is not supported before SDL 2.0.9")


### PR DESCRIPTION
Use mixer version 2.0.2 for Mix_OpenAudioDevice stub to be able to compile on
Ubuntu 18.04. Previously sdl version was used for check.

In 2.0.2 it is included:
http://hg.libsdl.org/SDL_mixer/file/c593f8bf25c3/SDL_mixer.h

In 2.0.1 it is not included:
http://hg.libsdl.org/SDL_mixer/file/7e59d684b070/SDL_mixer.h

Mix_OpenAudioDevice is also mentioned in changelog:
https://www.libsdl.org/projects/SDL_mixer/