### PR TITLE
Add HDC & hInstance to windows SysWMinfo struct

### DIFF
--- a/sdl/syswm.go
+++ b/sdl/syswm.go
@@ -70,6 +70,8 @@ type SysWMInfo struct {
 // WindowsInfo contains Microsoft Windows window information.
 type WindowsInfo struct {
 	Window unsafe.Pointer // the window handle
+	DeviceContext unsafe.Pointer // the device context handle
+	Instance unsafe.Pointer // the instance handle
 }
 
 // X11Info contains X Window System window information.


### PR DESCRIPTION
https://github.com/libsdl-org/SDL/blob/main/include/SDL_syswm.h#L231 SDL
includes HWND, HDC, and HINSTANCE in the windows-related SysWMinfo
structure.  These are useful values if you have occasion to open up the
guts and do something inadvisable & it would be nice if they were
available