### PR TITLE
sdl/render: Fix naked return value assignments in `RenderWindowToLogical` and `RenderLogicalToWindow`

### DIFF
--- a/sdl/render.go
+++ b/sdl/render.go
@@ -1263,8 +1263,8 @@ func (renderer *Renderer) RenderWindowToLogical(windowX, windowY int) (logicalX,
 	_logicalX := C.float(0)
 	_logicalY := C.float(0)
 	C.SDL_RenderWindowToLogical(renderer.cptr(), _windowX, _windowY, &_logicalX, &_logicalY)
-	logicalX = float32(logicalX)
-	logicalY = float32(logicalY)
+	logicalX = float32(_logicalX)
+	logicalY = float32(_logicalY)
 	return
 }
 

--- a/sdl/render.go
+++ b/sdl/render.go
@@ -1277,8 +1277,8 @@ func (renderer *Renderer) RenderLogicalToWindow(logicalX, logicalY float32) (win
 	_windowX := C.int(0)
 	_windowY := C.int(0)
 	C.SDL_RenderLogicalToWindow(renderer.cptr(), _logicalX, _logicalY, &_windowX, &_windowY)
-	windowX = int(windowX)
-	windowY = int(windowY)
+	windowX = int(_windowX)
+	windowY = int(_windowY)
 	return
 }
 


### PR DESCRIPTION
I've been trying to use the `RenderWindowToLogical` and `RenderLogicalToWindow` methods in `sdl/render.go` to convert window coordinates into logical coordinates for mouse position, but it's been returning nothing but `0, 0` on every call.

The changes in this PR just fix some simple typos in the two methods where the naked return values were being assigned to themselves, rather than being assigned the results from the SDL function calls.