### PR TITLE
Prevent system_linux.go from compiling for android

### DIFF
--- a/sdl/system_linux.go
+++ b/sdl/system_linux.go
@@ -1,3 +1,4 @@
+// +build !android
 package sdl
 
 /*


### PR DESCRIPTION
Build failure for android:
../../../../go/pkg/mod/github.com/veandco/go-sdl2@v0.4.17/sdl/system_linux.go:42:26: could not determine kind of name for C.SDL_LinuxSetThreadPriority

The problem is described here https://groups.google.com/g/golang-nuts/c/ZTGMjhEV7uY?pli=1

When GOOS=android it compiles both *_android.go and *_linux.go files, so you need to explicitly disable the file for android, because android SDL headers do not have those linux functions


