### PR TITLE
sdl/surface.go: Fix incorrect pixel color reading for RGB888 in Surface.At

### DIFF
--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -653,7 +653,7 @@ func (surface *Surface) At(x, y int) color.Color {
 			return color.RGBA{pix[i], pix[i+3], pix[i+2], pix[i+1]}
 	*/
 	case PIXELFORMAT_RGB888:
-		return color.RGBA{pix[i], pix[i+1], pix[i+2], 0xff}
+		return color.RGBA{pix[i+2], pix[i+1], pix[i], 0xff}
 	default:
 		panic("Not implemented yet")
 	}

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -645,18 +645,8 @@ func (surface *Surface) Bounds() image.Rectangle {
 func (surface *Surface) At(x, y int) color.Color {
 	pix := surface.Pixels()
 	i := int32(y)*surface.Pitch + int32(x)*int32(surface.Format.BytesPerPixel)
-	switch surface.Format.Format {
-	/*
-		case PIXELFORMAT_ARGB8888:
-			return color.RGBA{pix[i+3], pix[i], pix[i+1], pix[i+2]}
-		case PIXELFORMAT_ABGR8888:
-			return color.RGBA{pix[i], pix[i+3], pix[i+2], pix[i+1]}
-	*/
-	case PIXELFORMAT_RGB888:
-		return color.RGBA{pix[i+2], pix[i+1], pix[i], 0xff}
-	default:
-		panic("Not implemented yet")
-	}
+	r, g, b, a := GetRGBA(*((*uint32)(unsafe.Pointer(&pix[i]))), surface.Format)
+	return color.RGBA{r, g, b, a}
 }
 
 // Set the color of the pixel at (x, y) using this surface's color model to


### PR DESCRIPTION
Given the following drawing code:

```go
surface, err := window.GetSurface()
if err != nil {
	panic(err)
}
surface.FillRect(nil, 0xffffff00) // yellow

cpy, err := surface.Duplicate()
if err != nil {
	panic(err)
}
cpy.FillRect(nil, 0xff996633) // brown
// draws the bottom-right box:
for y := 110; y < 200; y++ {
	for x := 110; x < 200; x++ {
		surface.Set(x, y, cpy.At(x, y))
	}
}
// draws the top-left box:
cpy.Blit(&sdl.Rect{10, 10, 90, 90}, surface, &sdl.Rect{10, 10, 90, 90})
```

**Actual:**
<img src="https://user-images.githubusercontent.com/5958957/161170075-cb82c313-2c76-4d46-bfde-b90a254c94a3.png" width="300">

**Expected:**
<img src="https://user-images.githubusercontent.com/5958957/161170031-e69d10b1-19e4-46fc-a5bc-8c24d525b3e6.png" width="300">

It appears that, in `Surface.At`, the order of pixel data access is incorrect when initializing `color.RGBA`. This PR fixes that.