### PR TITLE
Fix my panic on (*Surface).Set()

### DIFF
--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -797,7 +797,7 @@ func (surface *Surface) Set(x, y int, c color.Color) {
 		}
 		*buf = b<<11 | g<<6 | r<<1 | a
 	case PIXELFORMAT_RGBA8888:
-		col := surface.ColorModel().Convert(c).(color.RGBA)
+		col := surface.ColorModel().Convert(c).(RGBA8888)
 		pix[i+3] = col.R
 		pix[i+2] = col.G
 		pix[i+1] = col.B


### PR DESCRIPTION
Your color models return the color.Color implementation of type they are converting to. This contradicts to the code of (*Surface).Set.
sdl/pixel.go:
```
func rgba8888Model(c color.Color) color.Color {
	if _, ok := c.(color.RGBA); ok {
		return c
	}
	r, g, b, a := c.RGBA()
	return RGBA8888{uint8(r), uint8(g), uint8(b), uint8(a)}
}
```