### PR TITLE
Change Windows static compile to include more static libraries

### DIFF
--- a/gfx/sdl_gfx_cgo_static.go
+++ b/gfx/sdl_gfx_cgo_static.go
@@ -6,8 +6,8 @@ package gfx
 //#cgo LDFLAGS: -L${SRCDIR}/../.go-sdl2-libs
 //#cgo linux,386 LDFLAGS: -lSDL2_gfx_linux_386 -lSDL2_linux_386 -Wl,--no-undefined -lm -ldl -lasound -lm -ldl -lpthread -lX11 -lXext -lXcursor -lXinerama -lXi -lXrandr -lXss -lXxf86vm -lpthread -lrt
 //#cgo linux,amd64 LDFLAGS: -lSDL2_gfx_linux_amd64 -lSDL2_linux_amd64 -Wl,--no-undefined -lm -ldl -lasound -lm -ldl -lpthread -lX11 -lXext -lXcursor -lXinerama -lXi -lXrandr -lXss -lXxf86vm -lpthread -lrt
-//#cgo windows,386 LDFLAGS: -lSDL2_gfx_windows_386 -lSDL2_windows_386 -Wl,--no-undefined -lSDL2main_windows_386 -Wl,--no-undefined -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -lsetupapi -static-libgcc
-//#cgo windows,amd64 LDFLAGS: -lSDL2_gfx_windows_amd64 -lSDL2_windows_amd64 -Wl,--no-undefined -lSDL2main_windows_amd64 -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -lsetupapi -static-libgcc
+//#cgo windows,386 LDFLAGS: -lSDL2_gfx_windows_386 -lSDL2_windows_386 -Wl,--no-undefined -lSDL2main_windows_386 -Wl,--no-undefined -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -lsetupapi -static
+//#cgo windows,amd64 LDFLAGS: -lSDL2_gfx_windows_amd64 -lSDL2_windows_amd64 -Wl,--no-undefined -lSDL2main_windows_amd64 -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -lsetupapi -static
 //#cgo darwin,amd64 LDFLAGS: -lSDL2_gfx_darwin_amd64 -lSDL2_darwin_amd64 -lm -liconv -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-framework,Metal
 //#cgo android,arm LDFLAGS: -lSDL2_gfx_android_arm -lSDL2_android_arm -Wl,--no-undefined -lm -ldl -llog -landroid -lGLESv2 -lGLESv1_CM
 //#cgo linux,arm,!android LDFLAGS: -L/opt/vc/lib -L/opt/vc/lib64 -lSDL2_gfx_linux_arm -lSDL2_linux_arm -Wl,--no-undefined -lm -ldl -liconv -lbcm_host -lvcos -lvchiq_arm -pthread

--- a/img/sdl_image_cgo_static.go
+++ b/img/sdl_image_cgo_static.go
@@ -1,3 +1,4 @@
+//go:build static
 // +build static
 
 package img
@@ -6,8 +7,8 @@ package img
 //#cgo LDFLAGS: -L${SRCDIR}/../.go-sdl2-libs
 //#cgo linux,386 LDFLAGS: -lSDL2_image_linux_386 -Wl,--no-undefined -lpng_linux_386 -ljpeg_linux_386 -lSDL2_linux_386 -lm -ldl -lz -lasound -lm -ldl -lpthread -lX11 -lXext -lXcursor -lXinerama -lXi -lXrandr -lXss -lXxf86vm -lpthread -lrt
 //#cgo linux,amd64 LDFLAGS: -lSDL2_image_linux_amd64 -Wl,--no-undefined -lpng_linux_amd64 -ljpeg_linux_amd64 -lSDL2_linux_amd64 -lm -ldl -lz -lasound -lm -ldl -lpthread -lX11 -lXext -lXcursor -lXinerama -lXi -lXrandr -lXss -lXxf86vm -lpthread -lrt
-//#cgo windows,386 LDFLAGS: -lSDL2_image_windows_386 -Wl,--no-undefined -lpng_windows_386 -ljpeg_windows_386 -lz_windows_386 -lSDL2_windows_386 -lSDL2main_windows_386 -Wl,--no-undefined -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -lsetupapi -static-libgcc
-//#cgo windows,amd64 LDFLAGS: -lSDL2_image_windows_amd64 -Wl,--no-undefined -lpng_windows_amd64 -ljpeg_windows_amd64 -lz_windows_amd64 -lSDL2_windows_amd64 -lSDL2main_windows_amd64 -Wl,--no-undefined -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -lsetupapi -static-libgcc
+//#cgo windows,386 LDFLAGS: -lSDL2_image_windows_386 -Wl,--no-undefined -lpng_windows_386 -ljpeg_windows_386 -lz_windows_386 -lSDL2_windows_386 -lSDL2main_windows_386 -Wl,--no-undefined -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -lsetupapi -static
+//#cgo windows,amd64 LDFLAGS: -lSDL2_image_windows_amd64 -Wl,--no-undefined -lpng_windows_amd64 -ljpeg_windows_amd64 -lz_windows_amd64 -lSDL2_windows_amd64 -lSDL2main_windows_amd64 -Wl,--no-undefined -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -lsetupapi -static
 //#cgo darwin,amd64 LDFLAGS: -lSDL2_image_darwin_amd64 -lSDL2_darwin_amd64 -lpng_darwin_amd64 -ljpeg_darwin_amd64 -lm -lz -liconv -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-framework,Metal
 //#cgo android,arm LDFLAGS: -lSDL2_image_android_arm -Wl,--no-undefined -lpng_android_arm -ljpeg_android_arm -lSDL2_android_arm -lm -ldl -lz -llog -landroid -lGLESv2 -lGLESv1_CM
 //#cgo linux,arm,!android LDFLAGS: -L/opt/vc/lib -L/opt/vc/lib64 -lSDL2_image_linux_arm -Wl,--no-undefined -lpng_linux_arm -ljpeg_linux_arm -lSDL2_linux_arm -lm -ldl -lz -liconv -lbcm_host -lvcos -lvchiq_arm -pthread

--- a/mix/sdl_mixer_cgo_static.go
+++ b/mix/sdl_mixer_cgo_static.go
@@ -1,3 +1,4 @@
+//go:build static
 // +build static
 
 package mix
@@ -6,8 +7,8 @@ package mix
 //#cgo LDFLAGS: -L${SRCDIR}/../.go-sdl2-libs
 //#cgo linux,386 LDFLAGS: -lSDL2_mixer_linux_386 -Wl,--no-undefined -lmpg123_linux_386 -lvorbisfile_linux_386 -lvorbis_linux_386 -logg_linux_386 -lSDL2_linux_386 -lm -ldl -lasound -lm -ldl -lstdc++ -lpthread -lX11 -lXext -lXcursor -lXinerama -lXi -lXrandr -lXss -lXxf86vm -lpthread -lrt
 //#cgo linux,amd64 LDFLAGS: -lSDL2_mixer_linux_amd64 -Wl,--no-undefined -lmpg123_linux_amd64 -lvorbisfile_linux_amd64 -lvorbis_linux_amd64 -logg_linux_amd64 -lSDL2_linux_amd64 -lm -ldl -lstdc++ -lasound -lm -ldl -lpthread -lX11 -lXext -lXcursor -lXinerama -lXi -lXrandr -lXss -lXxf86vm -lpthread -lrt
-//#cgo windows,386 LDFLAGS: -lSDL2_mixer_windows_386 -Wl,--no-undefined -lmpg123_windows_386 -lvorbisfile_windows_386 -lvorbis_windows_386 -logg_windows_386 -lSDL2_windows_386 -lSDL2main_windows_386 -lstdc++ -Wl,--no-undefined -lm -ldinput8 -ldxguid -ldxerr8 -lshlwapi -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -lsetupapi -static-libgcc
-//#cgo windows,amd64 LDFLAGS: -lSDL2_mixer_windows_amd64 -Wl,--no-undefined -lmpg123_windows_amd64 -lvorbisfile_windows_amd64 -lvorbis_windows_amd64 -logg_windows_amd64 -lSDL2_windows_amd64 -lSDL2main_windows_amd64 -lstdc++ -Wl,--no-undefined -lm -ldinput8 -ldxguid -ldxerr8 -lshlwapi -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -lsetupapi -static-libgcc
+//#cgo windows,386 LDFLAGS: -lSDL2_mixer_windows_386 -Wl,--no-undefined -lmpg123_windows_386 -lvorbisfile_windows_386 -lvorbis_windows_386 -logg_windows_386 -lSDL2_windows_386 -lSDL2main_windows_386 -lstdc++ -Wl,--no-undefined -lm -ldinput8 -ldxguid -ldxerr8 -lshlwapi -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -lsetupapi -static
+//#cgo windows,amd64 LDFLAGS: -lSDL2_mixer_windows_amd64 -Wl,--no-undefined -lmpg123_windows_amd64 -lvorbisfile_windows_amd64 -lvorbis_windows_amd64 -logg_windows_amd64 -lSDL2_windows_amd64 -lSDL2main_windows_amd64 -lstdc++ -Wl,--no-undefined -lm -ldinput8 -ldxguid -ldxerr8 -lshlwapi -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -lsetupapi -static
 //#cgo darwin,amd64 LDFLAGS: -lSDL2_mixer_darwin_amd64 -lmpg123_darwin_amd64 -lvorbisfile_darwin_amd64 -lvorbis_darwin_amd64 -logg_darwin_amd64 -lSDL2_darwin_amd64 -lm -liconv -lfreetype_darwin_amd64 -lz_darwin_amd64 -lSDL2_darwin_amd64 -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-framework,Metal
 //#cgo android,arm LDFLAGS: -lSDL2_mixer_android_arm -Wl,--no-undefined -lmpg123_android_arm -lvorbisfile_android_arm -lvorbis_android_arm -logg_android_arm -lSDL2_android_arm -lm -ldl -llog -landroid -lGLESv2 -lGLESv1_CM
 //#cgo linux,arm,!android LDFLAGS: -L/opt/vc/lib -L/opt/vc/lib64 -lSDL2_mixer_linux_arm -Wl,--no-undefined -lmpg123_linux_arm -lvorbisfile_linux_arm -lvorbis_linux_arm -logg_linux_arm -lSDL2_linux_arm -lm -ldl -liconv -lbcm_host -lvcos -lvchiq_arm -pthread

--- a/sdl/sdl_cgo_static.go
+++ b/sdl/sdl_cgo_static.go
@@ -1,3 +1,4 @@
+//go:build static
 // +build static
 
 package sdl
@@ -6,8 +7,8 @@ package sdl
 //#cgo LDFLAGS: -L${SRCDIR}/../.go-sdl2-libs
 //#cgo linux,386 LDFLAGS: -lSDL2_linux_386 -lm -ldl -lasound -lm -ldl -lpthread -lX11 -lXext -lXcursor -lXinerama -lXi -lXrandr -lXss -lXxf86vm -lpthread -lrt
 //#cgo linux,amd64 LDFLAGS: -lSDL2_linux_amd64 -lm -ldl -lasound -lm -ldl -lpthread -lX11 -lXext -lXcursor -lXinerama -lXi -lXrandr -lXss -lXxf86vm -lpthread -lrt
-//#cgo windows,386 LDFLAGS: -lSDL2_windows_386 -lSDL2main_windows_386 -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lsetupapi -lversion -luuid -static-libgcc
-//#cgo windows,amd64 LDFLAGS: -lSDL2_windows_amd64 -lSDL2main_windows_amd64 -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -lsetupapi -static-libgcc
+//#cgo windows,386 LDFLAGS: -lSDL2_windows_386 -lSDL2main_windows_386 -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lsetupapi -lversion -luuid -static
+//#cgo windows,amd64 LDFLAGS: -lSDL2_windows_amd64 -lSDL2main_windows_amd64 -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -lsetupapi -static
 //#cgo darwin,amd64 LDFLAGS: -lSDL2_darwin_amd64 -lm -liconv -Wl,-framework,OpenGL -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-framework,Metal
 //#cgo darwin,arm64 LDFLAGS: -lSDL2_darwin_arm64 -lm -liconv -Wl,-framework,OpenGL -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-framework,Metal
 //#cgo android,arm LDFLAGS: -lSDL2_android_arm -lm -ldl -llog -landroid -lGLESv2 -lGLESv1_CM

--- a/ttf/sdl_ttf_cgo_static.go
+++ b/ttf/sdl_ttf_cgo_static.go
@@ -1,3 +1,4 @@
+//go:build static
 // +build static
 
 package ttf
@@ -6,8 +7,8 @@ package ttf
 //#cgo LDFLAGS: -L${SRCDIR}/../.go-sdl2-libs
 //#cgo linux,386 LDFLAGS: -lSDL2_ttf_linux_386 -Wl,--no-undefined -lfreetype_linux_386 -lSDL2_linux_386 -lm -ldl -lasound -lm -ldl -lpthread -lX11 -lXext -lXcursor -lXinerama -lXi -lXrandr -lXss -lXxf86vm -lpthread -lrt
 //#cgo linux,amd64 LDFLAGS: -lSDL2_ttf_linux_amd64 -Wl,--no-undefined -lfreetype_linux_amd64 -lSDL2_linux_amd64 -lm -ldl -lasound -lm -ldl -lpthread -lX11 -lXext -lXcursor -lXinerama -lXi -lXrandr -lXss -lXxf86vm -lpthread -lrt
-//#cgo windows,386 LDFLAGS: -lSDL2_ttf_windows_386 -Wl,--no-undefined -lfreetype_windows_386 -lSDL2_windows_386 -lSDL2main_windows_386 -Wl,--no-undefined -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -lsetupapi -static-libgcc
-//#cgo windows,amd64 LDFLAGS: -lSDL2_ttf_windows_amd64 -Wl,--no-undefined -lfreetype_windows_amd64 -lSDL2_windows_amd64 -lSDL2main_windows_amd64 -Wl,--no-undefined -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -lsetupapi -static-libgcc
+//#cgo windows,386 LDFLAGS: -lSDL2_ttf_windows_386 -Wl,--no-undefined -lfreetype_windows_386 -lSDL2_windows_386 -lSDL2main_windows_386 -Wl,--no-undefined -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -lsetupapi -static
+//#cgo windows,amd64 LDFLAGS: -lSDL2_ttf_windows_amd64 -Wl,--no-undefined -lfreetype_windows_amd64 -lSDL2_windows_amd64 -lSDL2main_windows_amd64 -Wl,--no-undefined -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lversion -luuid -lsetupapi -static
 //#cgo darwin,amd64 LDFLAGS: -lSDL2_ttf_darwin_amd64 -lm -liconv -lfreetype_darwin_amd64 -lSDL2_darwin_amd64 -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-framework,Metal
 //#cgo android,arm LDFLAGS: -lSDL2_ttf_android_arm -Wl,--no-undefined -lfreetype_android_arm -lSDL2_android_arm -lm -ldl -llog -landroid -lGLESv2 -lGLESv1_CM
 //#cgo linux,arm,!android LDFLAGS: -L/opt/vc/lib -L/opt/vc/lib64 -lSDL2_ttf_linux_arm -Wl,--no-undefined -lfreetype_linux_arm -lSDL2_linux_arm -lm -ldl -liconv -lbcm_host -lvcos -lvchiq_arm -pthread


### PR DESCRIPTION
This will alleviate missing libstdc++ and winpthread. I verified this by running the static build `go build -a -tags static -ldflags "-s -w"` and looking at [Windows Process Explorer](https://learn.microsoft.com/en-us/sysinternals/downloads/process-explorer) to ensure that no dlls from mingw were linked against the binary.