### PR TITLE
ttf: binded TTF_FontFaceStyleName in sdl_ttf.go

### DIFF
--- a/ttf/sdl_ttf.go
+++ b/ttf/sdl_ttf.go
@@ -349,6 +349,14 @@ func (f *Font) FaceFamilyName() string {
 	return fname
 }
 
+// FaceStyleName returns the current font face family's style name from the loaded font.
+// (https://wiki.libsdl.org/SDL_ttf/TTF_FontFaceStyleName)
+func (f *Font) FaceStyleName() string {
+        _fname := C.TTF_FontFaceStyleName(f.f)
+        fname := C.GoString(_fname)
+        return fname
+}
+
 // GlyphMetrics contains glyph-specific rendering metrics.
 type GlyphMetrics struct {
 	MinX, MaxX int


### PR DESCRIPTION
Binded TTF_FontFaceStyleName to FaceStyleName() on the Font struct. Added a stub for SDL 2.0.0 support (TTF_FontFaceStyleName was not supported until version 2.0.12).

#552 