### PR TITLE
sdl: Bugfix the button rework

### DIFF
--- a/sdl/events.go
+++ b/sdl/events.go
@@ -472,7 +472,7 @@ type MouseMotionEvent struct {
 	Timestamp uint32     // timestamp of the event
 	WindowID  uint32     // the window with mouse focus, if any
 	Which     uint32     // the mouse instance id, or TOUCH_MOUSEID
-	State     ButtonMask // BUTTON_LEFT, BUTTON_MIDDLE, BUTTON_RIGHT, BUTTON_X1, BUTTON_X2
+	State     ButtonMask // masks for BUTTON_LEFT, BUTTON_MIDDLE, BUTTON_RIGHT, BUTTON_X1, BUTTON_X2
 	X         int32      // X coordinate, relative to window
 	Y         int32      // Y coordinate, relative to window
 	XRel      int32      // relative motion in the X direction
@@ -497,7 +497,7 @@ type MouseButtonEvent struct {
 	Timestamp uint32      // timestamp of the event
 	WindowID  uint32      // the window with mouse focus, if any
 	Which     uint32      // the mouse instance id, or TOUCH_MOUSEID
-	Button    ButtonMask  // BUTTON_LEFT, BUTTON_MIDDLE, BUTTON_RIGHT, BUTTON_X1, BUTTON_X2
+	Button    Button      // BUTTON_LEFT, BUTTON_MIDDLE, BUTTON_RIGHT, BUTTON_X1, BUTTON_X2
 	State     ButtonState // PRESSED, RELEASED
 	Clicks    uint8       // 1 for single-click, 2 for double-click, etc. (>= SDL 2.0.2)
 	X         int32       // X coordinate, relative to window
@@ -1157,7 +1157,7 @@ func goEvent(cevent *CEvent) Event {
 			Timestamp: uint32(e.timestamp),
 			WindowID:  uint32(e.windowID),
 			Which:     uint32(e.which),
-			Button:    ButtonMask(e.button),
+			Button:    Button(e.button),
 			State:     ButtonState(e.state),
 			Clicks:    uint8(e.clicks),
 			X:         int32(e.x),

--- a/sdl/mouse.go
+++ b/sdl/mouse.go
@@ -95,6 +95,10 @@ const (
 	ButtonX2     Button = C.SDL_BUTTON_X2     // x2 mouse button
 )
 
+func (b Button) Mask() ButtonMask {
+	return ButtonMask(1 << (b - 1))
+}
+
 // Used as a mask when testing buttons in buttonstate.
 type ButtonMask uint32
 
@@ -105,6 +109,10 @@ const (
 	ButtonX1Mask ButtonMask = 1 << (ButtonX1 - 1)     // x1 mouse button mask
 	ButtonX2Mask ButtonMask = 1 << (ButtonX2 - 1)     // x2 mouse button mask
 )
+
+func (m ButtonMask) Has(b Button) bool {
+	return m&b.Mask() != 0
+}
 
 // Cursor is a custom cursor created by CreateCursor() or CreateColorCursor().
 type Cursor C.SDL_Cursor


### PR DESCRIPTION
`MouseButtonEvent.button` is a `Button`, not a `ButtonMask`. On the other hand, it is correct that `MouseMotionEvent`, `GetRelativeMouseState`, `GetMouseState` and `GetGlobalMouseState` all deal with `ButtonMask`.

The utility functions to convert between `Button` and `ButtonMask` mentioned in the example [here](https://github.com/veandco/go-sdl2/pull/532) was not committed:  so I added them also since they sounded nice.

So the correct way to check for a right button in a `MouseButtonEvent e`
```
if e.Button == sdl.ButtonRight {...}
```
While for a `MouseMotionEvent e` it would be:

```
if e.State.Has(sdl.ButtonLeft) {...}

or

if e.State&sdl.ButtonMaskLeft != 0 {...}
```