### PR TITLE
mix: avoid segfault race condition on HookMusicFinished

### DIFF
--- a/mix/sdl_mixer.go
+++ b/mix/sdl_mixer.go
@@ -743,7 +743,9 @@ func HookMusic(musicFunc func([]uint8)) {
 
 //export callHookMusicFinished
 func callHookMusicFinished() {
-	hookMusicFinishedFunc()
+	if hookMusicFinishedFunc != nil {
+		hookMusicFinishedFunc()
+	}
 }
 
 var hookMusicFinishedFunc func()


### PR DESCRIPTION
I got a segfault because hookMusicFinishedFunc was nil after I disabled the hook by 

`HookMusicFinished(nil)`

At the same time as I faded out my old music. This if statement should take care of it.
