### PR TITLE
sdl: handle adaptive vsync (-1) in GLGetSwapInterval

### DIFF
--- a/sdl/video.go
+++ b/sdl/video.go
@@ -1089,6 +1089,13 @@ func GLSetSwapInterval(interval int) error {
 // (https://wiki.libsdl.org/SDL_GL_GetSwapInterval)
 func GLGetSwapInterval() (int, error) {
 	i := int(C.SDL_GL_GetSwapInterval())
+	// -1 means adaptive vsync, not an error
+	// 0 means vsync off
+	// 1 means vsync on
+	if i == -1 || i == 0 || i == 1 {
+		return i, nil
+	}
+	// any other value should be an error
 	return i, errorFromInt(i)
 }
 


### PR DESCRIPTION
My system uses adaptive vsync by default, which means SDL_GL_GetSwapInterval returns -1, which go-sdl's errorFromInt() treated as an error. It couldn't get an error from SDL so it gave me "Unknown error (probably using old version of SDL2 and the function called is not supported?)"

(Note that SDL_GL_SetSwapInterval is correctly mapped, and a -1 there means an actual error)