### PR TITLE
Align colors in SDL package to Go specification

### DIFF
--- a/sdl/pixels.go
+++ b/sdl/pixels.go
@@ -84,7 +84,7 @@ type cPalette C.SDL_Palette
 
 // Color represents a color. This implements image/color.Color interface.
 // (https://wiki.libsdl.org/SDL_Color)
-type Color color.RGBA
+type Color color.NRGBA
 
 // Uint32 return uint32 representation of RGBA color.
 // NOTE: Don't use this as color for SDL2's rendering operations. For that, please use `sdl.MapRGB()` or `sdl.MapRGBA()`.

--- a/sdl/pixels.go
+++ b/sdl/pixels.go
@@ -365,17 +365,6 @@ func BitsPerPixel(format uint32) int {
 	return int(C.bitsPerPixel(C.Uint32(format)))
 }
 
-type RGB444 struct {
-	R, G, B byte
-}
-
-func (c RGB444) RGBA() (r, g, b, a uint32) {
-	r = uint32(c.R) << 12
-	g = uint32(c.G) << 12
-	b = uint32(c.B) << 12
-	return
-}
-
 var (
 	RGB444Model   color.Model = color.ModelFunc(rgb444Model)
 	RGB332Model   color.Model = color.ModelFunc(rgb332Model)
@@ -399,12 +388,30 @@ var (
 	ABGR8888Model color.Model = color.ModelFunc(abgr8888Model)
 )
 
+type RGB444 struct {
+	R, G, B byte
+}
+
+func (c RGB444) RGBA() (r, g, b, a uint32) {
+	nrgba := color.NRGBA{
+		R: c.R << 4,
+		G: c.G << 4,
+		B: c.B << 4,
+		A: 0xFF,
+	}
+	return nrgba.RGBA()
+}
+
 func rgb444Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(RGB444); ok {
 		return c
 	}
-	r, g, b, _ := c.RGBA()
-	return RGB444{uint8(r >> 12), uint8(g >> 12), uint8(b >> 12)}
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return RGB444{
+		R: nrgba.R >> 4,
+		G: nrgba.G >> 4,
+		B: nrgba.B >> 4,
+	}
 }
 
 type RGB332 struct {
@@ -412,18 +419,25 @@ type RGB332 struct {
 }
 
 func (c RGB332) RGBA() (r, g, b, a uint32) {
-	r = uint32(c.R) << 13
-	g = uint32(c.G) << 13
-	b = uint32(c.B) << 14
-	return
+	nrgba := color.NRGBA{
+		R: c.R << 5,
+		G: c.G << 5,
+		B: c.B << 6,
+		A: 0xFF,
+	}
+	return nrgba.RGBA()
 }
 
 func rgb332Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(RGB332); ok {
 		return c
 	}
-	r, g, b, _ := c.RGBA()
-	return RGB332{uint8(r >> 13), uint8(g >> 13), uint8(b >> 14)}
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return RGB332{
+		R: nrgba.R >> 5,
+		G: nrgba.G >> 5,
+		B: nrgba.B >> 6,
+	}
 }
 
 type RGB565 struct {
@@ -431,18 +445,25 @@ type RGB565 struct {
 }
 
 func (c RGB565) RGBA() (r, g, b, a uint32) {
-	r = uint32(c.R) << 11
-	g = uint32(c.G) << 10
-	b = uint32(c.B) << 11
-	return
+	nrgba := color.NRGBA{
+		R: c.R << 3,
+		G: c.G << 2,
+		B: c.B << 3,
+		A: 0xFF,
+	}
+	return nrgba.RGBA()
 }
 
 func rgb565Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(RGB565); ok {
 		return c
 	}
-	r, g, b, _ := c.RGBA()
-	return RGB565{uint8(r >> 11), uint8(g >> 10), uint8(b >> 11)}
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return RGB565{
+		R: nrgba.R >> 3,
+		G: nrgba.G >> 2,
+		B: nrgba.B >> 3,
+	}
 }
 
 type RGB555 struct {
@@ -450,18 +471,25 @@ type RGB555 struct {
 }
 
 func (c RGB555) RGBA() (r, g, b, a uint32) {
-	r = uint32(c.R) << 11
-	g = uint32(c.G) << 11
-	b = uint32(c.B) << 11
-	return
+	nrgba := color.NRGBA{
+		R: c.R << 3,
+		G: c.G << 3,
+		B: c.B << 3,
+		A: 0xFF,
+	}
+	return nrgba.RGBA()
 }
 
 func rgb555Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(RGB555); ok {
 		return c
 	}
-	r, g, b, _ := c.RGBA()
-	return RGB555{uint8(r >> 11), uint8(g >> 11), uint8(b >> 11)}
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return RGB555{
+		R: nrgba.R >> 3,
+		G: nrgba.G >> 3,
+		B: nrgba.B >> 3,
+	}
 }
 
 type BGR565 struct {
@@ -469,18 +497,25 @@ type BGR565 struct {
 }
 
 func (c BGR565) RGBA() (r, g, b, a uint32) {
-	r = uint32(c.R) << 11
-	g = uint32(c.G) << 10
-	b = uint32(c.B) << 11
-	return
+	nrgba := color.NRGBA{
+		R: c.R << 3,
+		G: c.G << 2,
+		B: c.B << 3,
+		A: 0xFF,
+	}
+	return nrgba.RGBA()
 }
 
 func bgr565Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(BGR565); ok {
 		return c
 	}
-	r, g, b, _ := c.RGBA()
-	return BGR565{uint8(b >> 11), uint8(g >> 10), uint8(r >> 11)}
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return BGR565{
+		B: uint8(nrgba.B >> 3),
+		G: uint8(nrgba.G >> 2),
+		R: uint8(nrgba.R >> 3),
+	}
 }
 
 type BGR555 struct {
@@ -488,18 +523,25 @@ type BGR555 struct {
 }
 
 func (c BGR555) RGBA() (r, g, b, a uint32) {
-	r = uint32(c.R) << 11
-	g = uint32(c.G) << 11
-	b = uint32(c.B) << 11
-	return
+	nrgba := color.NRGBA{
+		R: c.R << 3,
+		G: c.G << 3,
+		B: c.B << 3,
+		A: 0xFF,
+	}
+	return nrgba.RGBA()
 }
 
 func bgr555Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(BGR555); ok {
 		return c
 	}
-	r, g, b, _ := c.RGBA()
-	return BGR555{uint8(b >> 11), uint8(g >> 11), uint8(r >> 11)}
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return BGR555{
+		B: uint8(nrgba.B >> 3),
+		G: uint8(nrgba.G >> 3),
+		R: uint8(nrgba.R >> 3),
+	}
 }
 
 type RGB888 struct {
@@ -507,19 +549,25 @@ type RGB888 struct {
 }
 
 func (c RGB888) RGBA() (r, g, b, a uint32) {
-	r = uint32(c.R)
-	g = uint32(c.G)
-	b = uint32(c.B)
-	a = 255
-	return
+	nrgba := color.NRGBA{
+		R: c.R,
+		G: c.G,
+		B: c.B,
+		A: 0xFF,
+	}
+	return nrgba.RGBA()
 }
 
 func rgb888Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(RGB888); ok {
 		return c
 	}
-	r, g, b, _ := c.RGBA()
-	return RGB888{uint8(r), uint8(g), uint8(b)}
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return RGB888{
+		R: nrgba.R,
+		G: nrgba.G,
+		B: nrgba.B,
+	}
 }
 
 type BGR888 struct {
@@ -527,19 +575,25 @@ type BGR888 struct {
 }
 
 func (c BGR888) RGBA() (r, g, b, a uint32) {
-	b = uint32(c.B)
-	g = uint32(c.G)
-	r = uint32(c.R)
-	a = 255
-	return
+	nrgba := color.NRGBA{
+		R: c.R,
+		G: c.G,
+		B: c.B,
+		A: 0xFF,
+	}
+	return nrgba.RGBA()
 }
 
 func bgr888Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(BGR888); ok {
 		return c
 	}
-	r, g, b, _ := c.RGBA()
-	return BGR888{uint8(b), uint8(g), uint8(r)}
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return BGR888{
+		B: nrgba.B,
+		G: nrgba.G,
+		R: nrgba.R,
+	}
 }
 
 type ARGB4444 struct {
@@ -547,19 +601,26 @@ type ARGB4444 struct {
 }
 
 func (c ARGB4444) RGBA() (r, g, b, a uint32) {
-	a = uint32(c.A) << 4
-	r = uint32(c.R) << 4
-	g = uint32(c.G) << 4
-	b = uint32(c.B) << 4
-	return
+	nrgba := color.NRGBA{
+		R: c.R << 4,
+		G: c.G << 4,
+		B: c.B << 4,
+		A: c.A << 4,
+	}
+	return nrgba.RGBA()
 }
 
 func argb4444Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(ARGB4444); ok {
 		return c
 	}
-	r, g, b, a := c.RGBA()
-	return ARGB4444{uint8(a >> 4), uint8(r >> 4), uint8(g >> 4), uint8(b >> 4)}
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return ARGB4444{
+		nrgba.A >> 4,
+		nrgba.R >> 4,
+		nrgba.G >> 4,
+		nrgba.B >> 4,
+	}
 }
 
 type ABGR4444 struct {
@@ -567,19 +628,26 @@ type ABGR4444 struct {
 }
 
 func (c ABGR4444) RGBA() (r, g, b, a uint32) {
-	a = uint32(c.A) << 4
-	r = uint32(c.R) << 4
-	g = uint32(c.G) << 4
-	b = uint32(c.B) << 4
-	return
+	nrgba := color.NRGBA{
+		R: c.R << 4,
+		G: c.G << 4,
+		B: c.B << 4,
+		A: c.A << 4,
+	}
+	return nrgba.RGBA()
 }
 
 func abgr4444Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(ABGR4444); ok {
 		return c
 	}
-	r, g, b, a := c.RGBA()
-	return ABGR4444{uint8(a >> 4), uint8(b >> 4), uint8(g >> 4), uint8(r >> 4)}
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return ABGR4444{
+		nrgba.A >> 4,
+		nrgba.B >> 4,
+		nrgba.G >> 4,
+		nrgba.R >> 4,
+	}
 }
 
 type RGBA4444 struct {
@@ -587,19 +655,26 @@ type RGBA4444 struct {
 }
 
 func (c RGBA4444) RGBA() (r, g, b, a uint32) {
-	r = uint32(c.R) << 4
-	g = uint32(c.G) << 4
-	b = uint32(c.B) << 4
-	a = uint32(c.A) << 4
-	return
+	nrgba := color.NRGBA{
+		R: c.R << 4,
+		G: c.G << 4,
+		B: c.B << 4,
+		A: c.A << 4,
+	}
+	return nrgba.RGBA()
 }
 
 func rgba4444Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(RGBA4444); ok {
 		return c
 	}
-	r, g, b, a := c.RGBA()
-	return RGBA4444{uint8(r >> 4), uint8(g >> 4), uint8(b >> 4), uint8(a >> 4)}
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return RGBA4444{
+		nrgba.R >> 4,
+		nrgba.G >> 4,
+		nrgba.B >> 4,
+		nrgba.A >> 4,
+	}
 }
 
 type BGRA4444 struct {
@@ -607,19 +682,26 @@ type BGRA4444 struct {
 }
 
 func (c BGRA4444) RGBA() (r, g, b, a uint32) {
-	r = uint32(c.R) << 4
-	g = uint32(c.G) << 4
-	b = uint32(c.B) << 4
-	a = uint32(c.A) << 4
-	return
+	nrgba := color.NRGBA{
+		R: c.R << 4,
+		G: c.G << 4,
+		B: c.B << 4,
+		A: c.A << 4,
+	}
+	return nrgba.RGBA()
 }
 
 func bgra4444Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(BGRA4444); ok {
 		return c
 	}
-	r, g, b, a := c.RGBA()
-	return BGRA4444{uint8(b >> 4), uint8(g >> 4), uint8(r >> 4), uint8(a >> 4)}
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return BGRA4444{
+		nrgba.B >> 4,
+		nrgba.G >> 4,
+		nrgba.R >> 4,
+		nrgba.A >> 4,
+	}
 }
 
 type ARGB1555 struct {
@@ -627,27 +709,26 @@ type ARGB1555 struct {
 }
 
 func (c ARGB1555) RGBA() (r, g, b, a uint32) {
-	r = uint32(c.R) << 3
-	g = uint32(c.G) << 3
-	b = uint32(c.B) << 3
-	if c.A > 0 {
-		tmp := int32(-1)
-		a = uint32(tmp)
+	nrgba := color.NRGBA{
+		R: c.R << 3,
+		G: c.G << 3,
+		B: c.B << 3,
+		A: alphaByte(c.A),
 	}
-	return
+	return nrgba.RGBA()
 }
 
 func argb1555Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(ARGB1555); ok {
 		return c
 	}
-	r, g, b, a := c.RGBA()
-	if a > 0 {
-		a = 1
-	} else {
-		a = 0
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return ARGB1555{
+		A: alphaBit(nrgba.A),
+		R: nrgba.R >> 3,
+		G: nrgba.G >> 3,
+		B: nrgba.B >> 3,
 	}
-	return ARGB1555{uint8(a), uint8(r >> 3), uint8(g >> 3), uint8(b >> 3)}
 }
 
 type RGBA5551 struct {
@@ -655,27 +736,26 @@ type RGBA5551 struct {
 }
 
 func (c RGBA5551) RGBA() (r, g, b, a uint32) {
-	r = uint32(c.R) << 3
-	g = uint32(c.G) << 3
-	b = uint32(c.B) << 3
-	if c.A > 0 {
-		tmp := int32(-1)
-		a = uint32(tmp)
+	nrgba := color.NRGBA{
+		R: c.R << 3,
+		G: c.G << 3,
+		B: c.B << 3,
+		A: alphaByte(c.A),
 	}
-	return
+	return nrgba.RGBA()
 }
 
 func rgba5551Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(RGBA5551); ok {
 		return c
 	}
-	r, g, b, a := c.RGBA()
-	if a > 0 {
-		a = 1
-	} else {
-		a = 0
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return RGBA5551{
+		R: nrgba.R >> 3,
+		G: nrgba.G >> 3,
+		B: nrgba.B >> 3,
+		A: alphaBit(nrgba.A),
 	}
-	return RGBA5551{uint8(r >> 3), uint8(g >> 3), uint8(b >> 3), uint8(a)}
 }
 
 type ABGR1555 struct {
@@ -683,27 +763,26 @@ type ABGR1555 struct {
 }
 
 func (c ABGR1555) RGBA() (r, g, b, a uint32) {
-	r = uint32(c.R) << 3
-	g = uint32(c.G) << 3
-	b = uint32(c.B) << 3
-	if c.A > 0 {
-		tmp := int32(-1)
-		a = uint32(tmp)
+	nrgba := color.NRGBA{
+		R: c.R << 3,
+		G: c.G << 3,
+		B: c.B << 3,
+		A: alphaByte(c.A),
 	}
-	return
+	return nrgba.RGBA()
 }
 
 func abgr1555Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(ABGR1555); ok {
 		return c
 	}
-	r, g, b, a := c.RGBA()
-	if a > 0 {
-		a = 1
-	} else {
-		a = 0
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return ABGR1555{
+		A: alphaBit(nrgba.A),
+		R: nrgba.R >> 3,
+		G: nrgba.G >> 3,
+		B: nrgba.B >> 3,
 	}
-	return ABGR1555{uint8(a), uint8(r >> 3), uint8(g >> 3), uint8(b >> 3)}
 }
 
 type BGRA5551 struct {
@@ -711,27 +790,26 @@ type BGRA5551 struct {
 }
 
 func (c BGRA5551) RGBA() (r, g, b, a uint32) {
-	r = uint32(c.R) << 3
-	g = uint32(c.G) << 3
-	b = uint32(c.B) << 3
-	if c.A > 0 {
-		tmp := int32(-1)
-		a = uint32(tmp)
+	nrgba := color.NRGBA{
+		R: c.R << 3,
+		G: c.G << 3,
+		B: c.B << 3,
+		A: alphaByte(c.A),
 	}
-	return
+	return nrgba.RGBA()
 }
 
 func bgra5551Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(BGRA5551); ok {
 		return c
 	}
-	r, g, b, a := c.RGBA()
-	if a > 0 {
-		a = 1
-	} else {
-		a = 0
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return BGRA5551{
+		B: nrgba.B >> 3,
+		G: nrgba.G >> 3,
+		R: nrgba.R >> 3,
+		A: alphaBit(nrgba.A),
 	}
-	return BGRA5551{uint8(b >> 3), uint8(g >> 3), uint8(r >> 3), uint8(a)}
 }
 
 type RGBA8888 struct {
@@ -739,19 +817,26 @@ type RGBA8888 struct {
 }
 
 func (c RGBA8888) RGBA() (r, g, b, a uint32) {
-	r = uint32(c.R)
-	g = uint32(c.G)
-	b = uint32(c.B)
-	a = uint32(c.A)
-	return
+	nrgba := color.NRGBA{
+		R: c.R,
+		G: c.G,
+		B: c.B,
+		A: c.A,
+	}
+	return nrgba.RGBA()
 }
 
 func rgba8888Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(RGBA8888); ok {
 		return c
 	}
-	r, g, b, a := c.RGBA()
-	return RGBA8888{uint8(r), uint8(g), uint8(b), uint8(a)}
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return RGBA8888{
+		R: nrgba.R,
+		G: nrgba.G,
+		B: nrgba.B,
+		A: nrgba.A,
+	}
 }
 
 type BGRA8888 struct {
@@ -759,19 +844,26 @@ type BGRA8888 struct {
 }
 
 func (c BGRA8888) RGBA() (r, g, b, a uint32) {
-	b = uint32(c.B)
-	g = uint32(c.G)
-	r = uint32(c.R)
-	a = uint32(c.A)
-	return
+	nrgba := color.NRGBA{
+		R: c.R,
+		G: c.G,
+		B: c.B,
+		A: c.A,
+	}
+	return nrgba.RGBA()
 }
 
 func bgra8888Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(BGRA8888); ok {
 		return c
 	}
-	r, g, b, a := c.RGBA()
-	return BGRA8888{uint8(b), uint8(g), uint8(r), uint8(a)}
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return BGRA8888{
+		B: nrgba.B,
+		G: nrgba.G,
+		R: nrgba.R,
+		A: nrgba.A,
+	}
 }
 
 type ARGB8888 struct {
@@ -779,19 +871,26 @@ type ARGB8888 struct {
 }
 
 func (c ARGB8888) RGBA() (r, g, b, a uint32) {
-	a = uint32(c.A)
-	r = uint32(c.R)
-	g = uint32(c.G)
-	b = uint32(c.B)
-	return
+	nrgba := color.NRGBA{
+		R: c.R,
+		G: c.G,
+		B: c.B,
+		A: c.A,
+	}
+	return nrgba.RGBA()
 }
 
 func argb8888Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(ARGB8888); ok {
 		return c
 	}
-	r, g, b, a := c.RGBA()
-	return ARGB8888{uint8(a), uint8(r), uint8(g), uint8(b)}
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return ARGB8888{
+		A: nrgba.A,
+		R: nrgba.R,
+		G: nrgba.G,
+		B: nrgba.B,
+	}
 }
 
 type ABGR8888 struct {
@@ -799,17 +898,38 @@ type ABGR8888 struct {
 }
 
 func (c ABGR8888) RGBA() (r, g, b, a uint32) {
-	a = uint32(c.A)
-	r = uint32(c.R)
-	g = uint32(c.G)
-	b = uint32(c.B)
-	return
+	nrgba := color.NRGBA{
+		R: c.R,
+		G: c.G,
+		B: c.B,
+		A: c.A,
+	}
+	return nrgba.RGBA()
 }
 
 func abgr8888Model(c color.Color) color.Color {
-	if _, ok := c.(color.RGBA); ok {
+	if _, ok := c.(ABGR8888); ok {
 		return c
 	}
-	r, g, b, a := c.RGBA()
-	return ABGR8888{uint8(a), uint8(b), uint8(g), uint8(r)}
+	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
+	return ABGR8888{
+		A: nrgba.A,
+		B: nrgba.B,
+		G: nrgba.G,
+		R: nrgba.R,
+	}
+}
+
+func alphaBit(alpha byte) byte {
+	if alpha == 0 {
+		return 0
+	}
+	return 1
+}
+
+func alphaByte(alphaBit byte) byte {
+	if alphaBit == 0 {
+		return 0
+	}
+	return 0xFF
 }

--- a/sdl/pixels.go
+++ b/sdl/pixels.go
@@ -394,9 +394,9 @@ type RGB444 struct {
 
 func (c RGB444) RGBA() (r, g, b, a uint32) {
 	nrgba := color.NRGBA{
-		R: c.R << 4,
-		G: c.G << 4,
-		B: c.B << 4,
+		R: upscale4to8bit(c.R),
+		G: upscale4to8bit(c.G),
+		B: upscale4to8bit(c.B),
 		A: 0xFF,
 	}
 	return nrgba.RGBA()
@@ -408,9 +408,9 @@ func rgb444Model(c color.Color) color.Color {
 	}
 	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
 	return RGB444{
-		R: nrgba.R >> 4,
-		G: nrgba.G >> 4,
-		B: nrgba.B >> 4,
+		R: downscale8to4bit(nrgba.R),
+		G: downscale8to4bit(nrgba.G),
+		B: downscale8to4bit(nrgba.B),
 	}
 }
 
@@ -420,9 +420,9 @@ type RGB332 struct {
 
 func (c RGB332) RGBA() (r, g, b, a uint32) {
 	nrgba := color.NRGBA{
-		R: c.R << 5,
-		G: c.G << 5,
-		B: c.B << 6,
+		R: upscale3to8bit(c.R),
+		G: upscale3to8bit(c.G),
+		B: upscale2to8bit(c.B),
 		A: 0xFF,
 	}
 	return nrgba.RGBA()
@@ -434,9 +434,9 @@ func rgb332Model(c color.Color) color.Color {
 	}
 	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
 	return RGB332{
-		R: nrgba.R >> 5,
-		G: nrgba.G >> 5,
-		B: nrgba.B >> 6,
+		R: downscale8to3bit(nrgba.R),
+		G: downscale8to3bit(nrgba.G),
+		B: downscale8to2bit(nrgba.B),
 	}
 }
 
@@ -446,9 +446,9 @@ type RGB565 struct {
 
 func (c RGB565) RGBA() (r, g, b, a uint32) {
 	nrgba := color.NRGBA{
-		R: c.R << 3,
-		G: c.G << 2,
-		B: c.B << 3,
+		R: upscale5to8bit(c.R),
+		G: upscale6to8bit(c.G),
+		B: upscale5to8bit(c.B),
 		A: 0xFF,
 	}
 	return nrgba.RGBA()
@@ -460,9 +460,9 @@ func rgb565Model(c color.Color) color.Color {
 	}
 	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
 	return RGB565{
-		R: nrgba.R >> 3,
-		G: nrgba.G >> 2,
-		B: nrgba.B >> 3,
+		R: downscale8to5bit(nrgba.R),
+		G: downscale8to6bit(nrgba.G),
+		B: downscale8to5bit(nrgba.B),
 	}
 }
 
@@ -472,9 +472,9 @@ type RGB555 struct {
 
 func (c RGB555) RGBA() (r, g, b, a uint32) {
 	nrgba := color.NRGBA{
-		R: c.R << 3,
-		G: c.G << 3,
-		B: c.B << 3,
+		R: upscale5to8bit(c.R),
+		G: upscale5to8bit(c.G),
+		B: upscale5to8bit(c.B),
 		A: 0xFF,
 	}
 	return nrgba.RGBA()
@@ -486,9 +486,9 @@ func rgb555Model(c color.Color) color.Color {
 	}
 	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
 	return RGB555{
-		R: nrgba.R >> 3,
-		G: nrgba.G >> 3,
-		B: nrgba.B >> 3,
+		R: downscale8to5bit(nrgba.R),
+		G: downscale8to5bit(nrgba.G),
+		B: downscale8to5bit(nrgba.B),
 	}
 }
 
@@ -498,9 +498,9 @@ type BGR565 struct {
 
 func (c BGR565) RGBA() (r, g, b, a uint32) {
 	nrgba := color.NRGBA{
-		R: c.R << 3,
-		G: c.G << 2,
-		B: c.B << 3,
+		R: upscale5to8bit(c.R),
+		G: upscale6to8bit(c.G),
+		B: upscale5to8bit(c.B),
 		A: 0xFF,
 	}
 	return nrgba.RGBA()
@@ -512,9 +512,9 @@ func bgr565Model(c color.Color) color.Color {
 	}
 	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
 	return BGR565{
-		B: uint8(nrgba.B >> 3),
-		G: uint8(nrgba.G >> 2),
-		R: uint8(nrgba.R >> 3),
+		B: downscale8to5bit(nrgba.B),
+		G: downscale8to6bit(nrgba.G),
+		R: downscale8to5bit(nrgba.R),
 	}
 }
 
@@ -524,9 +524,9 @@ type BGR555 struct {
 
 func (c BGR555) RGBA() (r, g, b, a uint32) {
 	nrgba := color.NRGBA{
-		R: c.R << 3,
-		G: c.G << 3,
-		B: c.B << 3,
+		R: upscale5to8bit(c.R),
+		G: upscale5to8bit(c.G),
+		B: upscale5to8bit(c.B),
 		A: 0xFF,
 	}
 	return nrgba.RGBA()
@@ -538,9 +538,9 @@ func bgr555Model(c color.Color) color.Color {
 	}
 	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
 	return BGR555{
-		B: uint8(nrgba.B >> 3),
-		G: uint8(nrgba.G >> 3),
-		R: uint8(nrgba.R >> 3),
+		B: downscale8to5bit(nrgba.B),
+		G: downscale8to5bit(nrgba.G),
+		R: downscale8to5bit(nrgba.R),
 	}
 }
 
@@ -602,10 +602,10 @@ type ARGB4444 struct {
 
 func (c ARGB4444) RGBA() (r, g, b, a uint32) {
 	nrgba := color.NRGBA{
-		R: c.R << 4,
-		G: c.G << 4,
-		B: c.B << 4,
-		A: c.A << 4,
+		R: upscale4to8bit(c.R),
+		G: upscale4to8bit(c.G),
+		B: upscale4to8bit(c.B),
+		A: upscale4to8bit(c.A),
 	}
 	return nrgba.RGBA()
 }
@@ -616,10 +616,10 @@ func argb4444Model(c color.Color) color.Color {
 	}
 	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
 	return ARGB4444{
-		nrgba.A >> 4,
-		nrgba.R >> 4,
-		nrgba.G >> 4,
-		nrgba.B >> 4,
+		A: downscale8to4bit(nrgba.A),
+		R: downscale8to4bit(nrgba.R),
+		G: downscale8to4bit(nrgba.G),
+		B: downscale8to4bit(nrgba.B),
 	}
 }
 
@@ -629,10 +629,10 @@ type ABGR4444 struct {
 
 func (c ABGR4444) RGBA() (r, g, b, a uint32) {
 	nrgba := color.NRGBA{
-		R: c.R << 4,
-		G: c.G << 4,
-		B: c.B << 4,
-		A: c.A << 4,
+		R: upscale4to8bit(c.R),
+		G: upscale4to8bit(c.G),
+		B: upscale4to8bit(c.B),
+		A: upscale4to8bit(c.A),
 	}
 	return nrgba.RGBA()
 }
@@ -643,10 +643,10 @@ func abgr4444Model(c color.Color) color.Color {
 	}
 	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
 	return ABGR4444{
-		nrgba.A >> 4,
-		nrgba.B >> 4,
-		nrgba.G >> 4,
-		nrgba.R >> 4,
+		A: downscale8to4bit(nrgba.A),
+		B: downscale8to4bit(nrgba.B),
+		G: downscale8to4bit(nrgba.G),
+		R: downscale8to4bit(nrgba.R),
 	}
 }
 
@@ -656,10 +656,10 @@ type RGBA4444 struct {
 
 func (c RGBA4444) RGBA() (r, g, b, a uint32) {
 	nrgba := color.NRGBA{
-		R: c.R << 4,
-		G: c.G << 4,
-		B: c.B << 4,
-		A: c.A << 4,
+		R: upscale4to8bit(c.R),
+		G: upscale4to8bit(c.G),
+		B: upscale4to8bit(c.B),
+		A: upscale4to8bit(c.A),
 	}
 	return nrgba.RGBA()
 }
@@ -670,10 +670,10 @@ func rgba4444Model(c color.Color) color.Color {
 	}
 	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
 	return RGBA4444{
-		nrgba.R >> 4,
-		nrgba.G >> 4,
-		nrgba.B >> 4,
-		nrgba.A >> 4,
+		R: downscale8to4bit(nrgba.R),
+		G: downscale8to4bit(nrgba.G),
+		B: downscale8to4bit(nrgba.B),
+		A: downscale8to4bit(nrgba.A),
 	}
 }
 
@@ -683,10 +683,10 @@ type BGRA4444 struct {
 
 func (c BGRA4444) RGBA() (r, g, b, a uint32) {
 	nrgba := color.NRGBA{
-		R: c.R << 4,
-		G: c.G << 4,
-		B: c.B << 4,
-		A: c.A << 4,
+		R: upscale4to8bit(c.R),
+		G: upscale4to8bit(c.G),
+		B: upscale4to8bit(c.B),
+		A: upscale4to8bit(c.A),
 	}
 	return nrgba.RGBA()
 }
@@ -697,10 +697,10 @@ func bgra4444Model(c color.Color) color.Color {
 	}
 	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
 	return BGRA4444{
-		nrgba.B >> 4,
-		nrgba.G >> 4,
-		nrgba.R >> 4,
-		nrgba.A >> 4,
+		B: downscale8to4bit(nrgba.B),
+		G: downscale8to4bit(nrgba.G),
+		R: downscale8to4bit(nrgba.R),
+		A: downscale8to4bit(nrgba.A),
 	}
 }
 
@@ -710,10 +710,10 @@ type ARGB1555 struct {
 
 func (c ARGB1555) RGBA() (r, g, b, a uint32) {
 	nrgba := color.NRGBA{
-		R: c.R << 3,
-		G: c.G << 3,
-		B: c.B << 3,
-		A: alphaByte(c.A),
+		R: upscale5to8bit(c.R),
+		G: upscale5to8bit(c.G),
+		B: upscale5to8bit(c.B),
+		A: upscale1to8bit(c.A),
 	}
 	return nrgba.RGBA()
 }
@@ -724,10 +724,10 @@ func argb1555Model(c color.Color) color.Color {
 	}
 	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
 	return ARGB1555{
-		A: alphaBit(nrgba.A),
-		R: nrgba.R >> 3,
-		G: nrgba.G >> 3,
-		B: nrgba.B >> 3,
+		A: downscale8to1bit(nrgba.A),
+		R: downscale8to5bit(nrgba.R),
+		G: downscale8to5bit(nrgba.G),
+		B: downscale8to5bit(nrgba.B),
 	}
 }
 
@@ -737,10 +737,10 @@ type RGBA5551 struct {
 
 func (c RGBA5551) RGBA() (r, g, b, a uint32) {
 	nrgba := color.NRGBA{
-		R: c.R << 3,
-		G: c.G << 3,
-		B: c.B << 3,
-		A: alphaByte(c.A),
+		R: upscale5to8bit(c.R),
+		G: upscale5to8bit(c.G),
+		B: upscale5to8bit(c.B),
+		A: upscale1to8bit(c.A),
 	}
 	return nrgba.RGBA()
 }
@@ -751,10 +751,10 @@ func rgba5551Model(c color.Color) color.Color {
 	}
 	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
 	return RGBA5551{
-		R: nrgba.R >> 3,
-		G: nrgba.G >> 3,
-		B: nrgba.B >> 3,
-		A: alphaBit(nrgba.A),
+		R: downscale8to5bit(nrgba.R),
+		G: downscale8to5bit(nrgba.G),
+		B: downscale8to5bit(nrgba.B),
+		A: downscale8to1bit(nrgba.A),
 	}
 }
 
@@ -764,10 +764,10 @@ type ABGR1555 struct {
 
 func (c ABGR1555) RGBA() (r, g, b, a uint32) {
 	nrgba := color.NRGBA{
-		R: c.R << 3,
-		G: c.G << 3,
-		B: c.B << 3,
-		A: alphaByte(c.A),
+		R: upscale5to8bit(c.R),
+		G: upscale5to8bit(c.G),
+		B: upscale5to8bit(c.B),
+		A: upscale1to8bit(c.A),
 	}
 	return nrgba.RGBA()
 }
@@ -778,10 +778,10 @@ func abgr1555Model(c color.Color) color.Color {
 	}
 	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
 	return ABGR1555{
-		A: alphaBit(nrgba.A),
-		R: nrgba.R >> 3,
-		G: nrgba.G >> 3,
-		B: nrgba.B >> 3,
+		A: downscale8to1bit(nrgba.A),
+		R: downscale8to5bit(nrgba.R),
+		G: downscale8to5bit(nrgba.G),
+		B: downscale8to5bit(nrgba.B),
 	}
 }
 
@@ -791,10 +791,10 @@ type BGRA5551 struct {
 
 func (c BGRA5551) RGBA() (r, g, b, a uint32) {
 	nrgba := color.NRGBA{
-		R: c.R << 3,
-		G: c.G << 3,
-		B: c.B << 3,
-		A: alphaByte(c.A),
+		R: upscale5to8bit(c.R),
+		G: upscale5to8bit(c.G),
+		B: upscale5to8bit(c.B),
+		A: upscale1to8bit(c.A),
 	}
 	return nrgba.RGBA()
 }
@@ -805,10 +805,10 @@ func bgra5551Model(c color.Color) color.Color {
 	}
 	nrgba := color.NRGBAModel.Convert(c).(color.NRGBA)
 	return BGRA5551{
-		B: nrgba.B >> 3,
-		G: nrgba.G >> 3,
-		R: nrgba.R >> 3,
-		A: alphaBit(nrgba.A),
+		B: downscale8to5bit(nrgba.B),
+		G: downscale8to5bit(nrgba.G),
+		R: downscale8to5bit(nrgba.R),
+		A: downscale8to1bit(nrgba.A),
 	}
 }
 
@@ -920,16 +920,56 @@ func abgr8888Model(c color.Color) color.Color {
 	}
 }
 
-func alphaBit(alpha byte) byte {
+func downscale8to1bit(alpha byte) byte {
 	if alpha == 0 {
 		return 0
 	}
 	return 1
 }
 
-func alphaByte(alphaBit byte) byte {
+func downscale8to2bit(in byte) byte {
+	return in >> 6
+}
+
+func downscale8to3bit(in byte) byte {
+	return in >> 5
+}
+
+func downscale8to4bit(in byte) byte {
+	return in >> 4
+}
+
+func downscale8to5bit(in byte) byte {
+	return in >> 3
+}
+
+func downscale8to6bit(in byte) byte {
+	return in >> 2
+}
+
+func upscale1to8bit(alphaBit byte) byte {
 	if alphaBit == 0 {
 		return 0
 	}
 	return 0xFF
+}
+
+func upscale2to8bit(in byte) byte {
+	return in<<6 | in<<4 | in<<2 | in
+}
+
+func upscale3to8bit(in byte) byte {
+	return in<<5 | in<<2 | (in>>1)&0b11
+}
+
+func upscale4to8bit(in byte) byte {
+	return in<<4 | in
+}
+
+func upscale5to8bit(in byte) byte {
+	return in<<3 | (in>>2)&0b111
+}
+
+func upscale6to8bit(in byte) byte {
+	return in<<2 | (in>>4)&0b11
 }

--- a/sdl/struct_test.go
+++ b/sdl/struct_test.go
@@ -87,7 +87,7 @@ func TestStructABI(t *testing.T) {
 		{TouchFingerEvent{}, cTouchFingerEvent{}, nil},
 		{MultiGestureEvent{}, cMultiGestureEvent{}, nil},
 		{DollarGestureEvent{}, cDollarGestureEvent{}, nil},
-		{tDropEvent{}, cDropEvent{}, dropEventEdgeCase},
+		{DropEvent{}, cDropEvent{}, dropEventEdgeCase},
 		{UserEvent{}, cUserEvent{}, nil},
 		{SysWMEvent{}, cSysWMEvent{}, nil},
 	}

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -653,165 +653,150 @@ func (surface *Surface) At(x, y int) color.Color {
 	return color.RGBA{r, g, b, a}
 }
 
-// Set the color of the pixel at (x, y) using this surface's color model to
-// convert c to the appropriate color. This method is required for the
+// Set the color of the pixel at (x, y) using this surface's color format to
+// convert c to the appropriate byte sequence. This method is required for the
 // draw.Image interface. The surface may require locking before calling Set.
 func (surface *Surface) Set(x, y int, c color.Color) {
+	// All sdl2 colors are a subset of NRGBA so it is safe precision-wise to
+	// convert to NRGBA and use the color components from there.
+	nrgbaColor := color.NRGBAModel.Convert(c).(color.NRGBA)
+	colR, colG, colB, colA := nrgbaColor.R, nrgbaColor.G, nrgbaColor.B, nrgbaColor.A
+
 	pix := surface.Pixels()
 	i := int32(y)*surface.Pitch + int32(x)*int32(surface.Format.BytesPerPixel)
 	switch surface.Format.Format {
 	case PIXELFORMAT_ARGB8888:
-		col := surface.ColorModel().Convert(c).(ARGB8888)
-		pix[i+3] = col.A
-		pix[i+2] = col.R
-		pix[i+1] = col.G
-		pix[i+0] = col.B
+		pix[i+3] = colA
+		pix[i+2] = colR
+		pix[i+1] = colG
+		pix[i+0] = colB
 	case PIXELFORMAT_ABGR8888:
-		col := surface.ColorModel().Convert(c).(ABGR8888)
-		pix[i+3] = col.A
-		pix[i+2] = col.B
-		pix[i+1] = col.G
-		pix[i+0] = col.R
+		pix[i+3] = colA
+		pix[i+2] = colB
+		pix[i+1] = colG
+		pix[i+0] = colR
 	case PIXELFORMAT_RGB24, PIXELFORMAT_RGB888:
-		col := surface.ColorModel().Convert(c).(RGB888)
-		pix[i+2] = col.R
-		pix[i+1] = col.G
-		pix[i+0] = col.B
+		pix[i+2] = colR
+		pix[i+1] = colG
+		pix[i+0] = colB
 	case PIXELFORMAT_BGR24, PIXELFORMAT_BGR888:
-		col := surface.ColorModel().Convert(c).(BGR888)
-		pix[i+2] = col.B
-		pix[i+1] = col.G
-		pix[i+0] = col.R
+		pix[i+2] = colB
+		pix[i+1] = colG
+		pix[i+0] = colR
 	case PIXELFORMAT_RGB444:
-		col := surface.ColorModel().Convert(c).(RGB444)
 		buf := (*uint32)(unsafe.Pointer(&pix[i]))
-		r := uint32(col.R) >> 4 & 0x0F
-		g := uint32(col.G) >> 4 & 0x0F
-		b := uint32(col.B) >> 4 & 0x0F
+		r := uint32(colR) >> 4 & 0x0F
+		g := uint32(colG) >> 4 & 0x0F
+		b := uint32(colB) >> 4 & 0x0F
 		*buf = r<<8 | g<<4 | b
 	case PIXELFORMAT_RGB332:
-		col := surface.ColorModel().Convert(c).(RGB332)
 		buf := (*uint32)(unsafe.Pointer(&pix[i]))
-		r := uint32(col.R) >> 5 & 0x0F
-		g := uint32(col.G) >> 5 & 0x0F
-		b := uint32(col.B) >> 6 & 0x0F
+		r := uint32(colR) >> 5 & 0x0F
+		g := uint32(colG) >> 5 & 0x0F
+		b := uint32(colB) >> 6 & 0x0F
 		*buf = r<<5 | g<<2 | b
 	case PIXELFORMAT_RGB565:
-		col := surface.ColorModel().Convert(c).(RGB565)
 		buf := (*uint32)(unsafe.Pointer(&pix[i]))
-		r := uint32(col.R) >> 3 & 0xFF
-		g := uint32(col.G) >> 2 & 0xFF
-		b := uint32(col.B) >> 3 & 0xFF
+		r := uint32(colR) >> 3 & 0xFF
+		g := uint32(colG) >> 2 & 0xFF
+		b := uint32(colB) >> 3 & 0xFF
 		*buf = r<<11 | g<<5 | b
 	case PIXELFORMAT_RGB555:
-		col := surface.ColorModel().Convert(c).(RGB555)
 		buf := (*uint32)(unsafe.Pointer(&pix[i]))
-		r := uint32(col.R) >> 3 & 0xFF
-		g := uint32(col.G) >> 3 & 0xFF
-		b := uint32(col.B) >> 3 & 0xFF
+		r := uint32(colR) >> 3 & 0xFF
+		g := uint32(colG) >> 3 & 0xFF
+		b := uint32(colB) >> 3 & 0xFF
 		*buf = r<<10 | g<<5 | b
 	case PIXELFORMAT_BGR565:
-		col := surface.ColorModel().Convert(c).(BGR565)
 		buf := (*uint32)(unsafe.Pointer(&pix[i]))
-		r := uint32(col.R) >> 3 & 0xFF
-		g := uint32(col.G) >> 2 & 0xFF
-		b := uint32(col.B) >> 3 & 0xFF
+		r := uint32(colR) >> 3 & 0xFF
+		g := uint32(colG) >> 2 & 0xFF
+		b := uint32(colB) >> 3 & 0xFF
 		*buf = b<<11 | g<<5 | r
 	case PIXELFORMAT_BGR555:
-		col := surface.ColorModel().Convert(c).(BGR555)
 		buf := (*uint32)(unsafe.Pointer(&pix[i]))
-		r := uint32(col.R) >> 3 & 0xFF
-		g := uint32(col.G) >> 3 & 0xFF
-		b := uint32(col.B) >> 3 & 0xFF
+		r := uint32(colR) >> 3 & 0xFF
+		g := uint32(colG) >> 3 & 0xFF
+		b := uint32(colB) >> 3 & 0xFF
 		*buf = b<<10 | g<<5 | r
 	case PIXELFORMAT_ARGB4444:
-		col := surface.ColorModel().Convert(c).(ARGB4444)
 		buf := (*uint32)(unsafe.Pointer(&pix[i]))
-		a := uint32(col.A) >> 4 & 0x0F
-		r := uint32(col.R) >> 4 & 0x0F
-		g := uint32(col.G) >> 4 & 0x0F
-		b := uint32(col.B) >> 4 & 0x0F
+		a := uint32(colA) >> 4 & 0x0F
+		r := uint32(colR) >> 4 & 0x0F
+		g := uint32(colG) >> 4 & 0x0F
+		b := uint32(colB) >> 4 & 0x0F
 		*buf = a<<12 | r<<8 | g<<4 | b
 	case PIXELFORMAT_ABGR4444:
-		col := surface.ColorModel().Convert(c).(ABGR4444)
 		buf := (*uint32)(unsafe.Pointer(&pix[i]))
-		a := uint32(col.A) >> 4 & 0x0F
-		r := uint32(col.R) >> 4 & 0x0F
-		g := uint32(col.G) >> 4 & 0x0F
-		b := uint32(col.B) >> 4 & 0x0F
+		a := uint32(colA) >> 4 & 0x0F
+		r := uint32(colR) >> 4 & 0x0F
+		g := uint32(colG) >> 4 & 0x0F
+		b := uint32(colB) >> 4 & 0x0F
 		*buf = a<<12 | b<<8 | g<<4 | r
 	case PIXELFORMAT_RGBA4444:
-		col := surface.ColorModel().Convert(c).(RGBA4444)
 		buf := (*uint32)(unsafe.Pointer(&pix[i]))
-		r := uint32(col.R) >> 4 & 0x0F
-		g := uint32(col.G) >> 4 & 0x0F
-		b := uint32(col.B) >> 4 & 0x0F
-		a := uint32(col.A) >> 4 & 0x0F
+		r := uint32(colR) >> 4 & 0x0F
+		g := uint32(colG) >> 4 & 0x0F
+		b := uint32(colB) >> 4 & 0x0F
+		a := uint32(colA) >> 4 & 0x0F
 		*buf = r<<12 | g<<8 | b<<4 | a
 	case PIXELFORMAT_BGRA4444:
-		col := surface.ColorModel().Convert(c).(BGRA4444)
 		buf := (*uint32)(unsafe.Pointer(&pix[i]))
-		r := uint32(col.R) >> 4 & 0x0F
-		g := uint32(col.G) >> 4 & 0x0F
-		b := uint32(col.B) >> 4 & 0x0F
-		a := uint32(col.A) >> 4 & 0x0F
+		r := uint32(colR) >> 4 & 0x0F
+		g := uint32(colG) >> 4 & 0x0F
+		b := uint32(colB) >> 4 & 0x0F
+		a := uint32(colA) >> 4 & 0x0F
 		*buf = b<<12 | g<<8 | r<<4 | a
 	case PIXELFORMAT_ARGB1555:
-		col := surface.ColorModel().Convert(c).(ARGB1555)
 		buf := (*uint32)(unsafe.Pointer(&pix[i]))
-		r := uint32(col.R) >> 3 & 0xFF
-		g := uint32(col.G) >> 3 & 0xFF
-		b := uint32(col.B) >> 3 & 0xFF
+		r := uint32(colR) >> 3 & 0xFF
+		g := uint32(colG) >> 3 & 0xFF
+		b := uint32(colB) >> 3 & 0xFF
 		a := uint32(0)
-		if col.A > 0 {
+		if colA > 0 {
 			a = 1
 		}
 		*buf = a<<15 | r<<10 | g<<5 | b
 	case PIXELFORMAT_RGBA5551:
-		col := surface.ColorModel().Convert(c).(RGBA5551)
 		buf := (*uint32)(unsafe.Pointer(&pix[i]))
-		r := uint32(col.R) >> 3 & 0xFF
-		g := uint32(col.G) >> 3 & 0xFF
-		b := uint32(col.B) >> 3 & 0xFF
+		r := uint32(colR) >> 3 & 0xFF
+		g := uint32(colG) >> 3 & 0xFF
+		b := uint32(colB) >> 3 & 0xFF
 		a := uint32(0)
-		if col.A > 0 {
+		if colA > 0 {
 			a = 1
 		}
 		*buf = r<<11 | g<<6 | b<<1 | a
 	case PIXELFORMAT_ABGR1555:
-		col := surface.ColorModel().Convert(c).(ABGR1555)
 		buf := (*uint32)(unsafe.Pointer(&pix[i]))
-		r := uint32(col.R) >> 3 & 0xFF
-		g := uint32(col.G) >> 3 & 0xFF
-		b := uint32(col.B) >> 3 & 0xFF
+		r := uint32(colR) >> 3 & 0xFF
+		g := uint32(colG) >> 3 & 0xFF
+		b := uint32(colB) >> 3 & 0xFF
 		a := uint32(0)
-		if col.A > 0 {
+		if colA > 0 {
 			a = 1
 		}
 		*buf = a<<15 | b<<10 | g<<5 | r
 	case PIXELFORMAT_BGRA5551:
-		col := surface.ColorModel().Convert(c).(BGRA5551)
 		buf := (*uint32)(unsafe.Pointer(&pix[i]))
-		r := uint32(col.R) >> 3 & 0xFF
-		g := uint32(col.G) >> 3 & 0xFF
-		b := uint32(col.B) >> 3 & 0xFF
+		r := uint32(colR) >> 3 & 0xFF
+		g := uint32(colG) >> 3 & 0xFF
+		b := uint32(colB) >> 3 & 0xFF
 		a := uint32(0)
-		if col.A > 0 {
+		if colA > 0 {
 			a = 1
 		}
 		*buf = b<<11 | g<<6 | r<<1 | a
 	case PIXELFORMAT_RGBA8888:
-		col := surface.ColorModel().Convert(c).(RGBA8888)
-		pix[i+3] = col.R
-		pix[i+2] = col.G
-		pix[i+1] = col.B
-		pix[i+0] = col.A
+		pix[i+3] = colR
+		pix[i+2] = colG
+		pix[i+1] = colB
+		pix[i+0] = colA
 	case PIXELFORMAT_BGRA8888:
-		col := surface.ColorModel().Convert(c).(BGRA8888)
-		pix[i+3] = col.B
-		pix[i+2] = col.G
-		pix[i+1] = col.R
-		pix[i+0] = col.A
+		pix[i+3] = colB
+		pix[i+2] = colG
+		pix[i+1] = colR
+		pix[i+0] = colA
 	default:
 		panic("Unknown pixel format!")
 	}

--- a/sdl/surface.go
+++ b/sdl/surface.go
@@ -650,7 +650,7 @@ func (surface *Surface) At(x, y int) color.Color {
 	pix := surface.Pixels()
 	i := int32(y)*surface.Pitch + int32(x)*int32(surface.Format.BytesPerPixel)
 	r, g, b, a := GetRGBA(*((*uint32)(unsafe.Pointer(&pix[i]))), surface.Format)
-	return color.RGBA{r, g, b, a}
+	return color.NRGBA{R: r, G: g, B: b, A: a}
 }
 
 // Set the color of the pixel at (x, y) using this surface's color format to


### PR DESCRIPTION
Closes https://github.com/veandco/go-sdl2/issues/580

**This PR does the following changes:**
- It ensures that `Surface.Set` does not panic by handling colors correctly.
- It changes `Surface.At` to return `color.NRGBA` instead of `color.RGBA` which is the correct type for what is being returned (non-alpha-premultiplied color). This can be a breaking change if anyone ever expected a specific color from the method, despite the interface abstraction.
- It changes the `sdl.Color` type to `color.NRGBA` which is the correct representation of what is held in `sdl.Color` (non-alpha-premultiplied color). This is a breaking change. Preserving the `color.RGBA` type mapping would require more code rework.
- It fixes all of the color models to properly return 16bit-component alpha-premultiplied colors.
- It fixes a broken type reference in the `sdl` package

**Things to note:**
- The `color.RGBA` type in Go represents an alpha-premultiplied color and SDL2 appears to use standard non-alpha premultiplied colors everywhere. This is why `color.NRGBA` is the correct pick.
- The `Color.RGBA` method is expected to return 16bit (i.e. from 0x0000 to 0xFFFF) alpha-premultiplied color components.
- The PR makes heavy use of `color.NRGBA` and `color.NRGBAModel`, since these are the official ones and they have stable and optimized implementations for color conversions between alpha-premultiplied and non-alpha-premultiplied variants and from 8bit-component to 16bit-component colors.

**Side notes:**
- In the past I had written a [blog post](https://dev.to/mokiat/understanding-the-color-type-in-go-1k45) about Go's colors which can shed some light on the above considerations. Feel free to remove this section if such type of links are unacceptable here.
- While downscaling of bytes is trivial, upscaling is not so if you want to fill the whole scale. I have tried to come up with the proper bit-wise operation expressions but to double-check I have used the following Go program to empirically measure it: https://play.golang.com/p/fYrvt4TXFv2
