### PR TITLE
fixed readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ func main() {
 	for running {
 		for event := sdl.PollEvent(); event != nil; event = sdl.PollEvent() {
 			switch event.(type) {
-			case sdl.QuitEvent:
+			case *sdl.QuitEvent:
 				println("Quit")
 				running = false
 				break


### PR DESCRIPTION
hi,

tried to run the example and received:

```
# command-line-arguments
./main.go:34:9: impossible type switch case: sdl.QuitEvent
	event (variable of type sdl.Event) cannot have dynamic type sdl.QuitEvent (method GetTimestamp has pointer receiver)
```

Looks like a pointer is needed in the switch.

cheers,

val