### PR TITLE
Fix typo in function name IMG_LoadSizedSVG_RW.

### DIFF
--- a/img/sdl_image.go
+++ b/img/sdl_image.go
@@ -8,10 +8,10 @@ package img
 #if !(SDL_IMAGE_VERSION_ATLEAST(2,6,0))
 
 #if defined(WARN_OUTDATED)
-#pragma message("SDL_LoadSizedSVG_RW is not supported before SDL2_image 2.6.0")
+#pragma message("IMG_LoadSizedSVG_RW is not supported before SDL2_image 2.6.0")
 #endif
 
-static inline SDL_Surface* SDL_LoadSizedSVG_RW(SDL_RWops* src, int width, int height)
+static inline SDL_Surface* IMG_LoadSizedSVG_RW(SDL_RWops* src, int width, int height)
 {
 	SDL_Unsupported();
 	return NULL;


### PR DESCRIPTION
Building the master branch results in the following error:

go-sdl2/img/sdl_image.go:436:14: could not determine kind of name for C.IMG_LoadSizedSVG_RW

In sdl_image.go:14, instead of SDL_ it should be IMG_.

Github issue: https://github.com/veandco/go-sdl2/issues/602