### PR TITLE
set the correct version check for SDL_HINT_RENDER_METAL_PREFER_LOW_POWER_DEVICE

### DIFF
--- a/sdl/hints.go
+++ b/sdl/hints.go
@@ -8,6 +8,11 @@ package sdl
 
 #define SDL_HINT_JOYSTICK_IOKIT ""
 #define SDL_HINT_JOYSTICK_MFI ""
+
+#endif
+
+#if !(SDL_VERSION_ATLEAST(2,28,3))
+
 #define SDL_HINT_RENDER_METAL_PREFER_LOW_POWER_DEVICE ""
 
 #endif


### PR DESCRIPTION
SDL_HINT_RENDER_METAL_PREFER_LOW_POWER_DEVICE was added in 2.28.3, but they forgot to mention it in the release notes. 
You can see it here in 2.28.3: https://github.com/libsdl-org/SDL/blob/release-2.28.3/include/SDL_hints.h#L1486

If compiling go-sdl2 on a system with 2.28.3-2.28.5 (such as ubuntu 23.10), you get 6 sets of these warnings:

```
# github.com/veandco/go-sdl2/sdl
In file included from system.c:1:
hints.go:11: warning: "SDL_HINT_RENDER_METAL_PREFER_LOW_POWER_DEVICE" redefined
   11 | #define SDL_HINT_RENDER_METAL_PREFER_LOW_POWER_DEVICE ""
      | 
In file included from /usr/include/SDL2/SDL.h:47,
                 from /home/lundis/go/pkg/mod/github.com/veandco/go-sdl2@v0.5.0-alpha.6/sdl/sdl_wrapper.h:5,
                 from events.go:4:
/usr/include/SDL2/SDL_hints.h:1486: note: this is the location of the previous definition
 1486 | #define SDL_HINT_RENDER_METAL_PREFER_LOW_POWER_DEVICE "SDL_RENDER_METAL_PREFER_LOW_POWER_DEVICE"

```