### PR TITLE
README: Added an extra step for include/library flags in windows installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,10 @@ On __Windows__,
     * Put mingw-w64 binaries location into system `Path` environment variable (e.g. `C:\mingw64\bin`)
 4. Close and open terminal again so the new `Path` environment variable takes effect. Now we should be able to run `go build` inside the project directory.
 5. Download and install SDL2 runtime libraries from https://github.com/libsdl-org/SDL/releases. Extract and copy the `.dll` file into the project directory. After that, the program should become runnable.
-6. (Optional) You can repeat __Step 2__ for [SDL_image](https://github.com/libsdl-org/SDL_image/releases), [SDL_mixer](https://github.com/libsdl-org/SDL_mixer/releases), [SDL_ttf](https://github.com/libsdl-org/SDL_ttf/releases)
+6. Add compiler flags in your environment variables, so gcc can find SDL headers when compiling:
+   - `CGO_CFLAGS=-IC:\mingw64\include`
+   - `CGO_LDFLAGS=-LC:\mingw64\lib -lSDL2`
+7. (Optional) You can repeat __Step 2__ for [SDL_image](https://github.com/libsdl-org/SDL_image/releases), [SDL_mixer](https://github.com/libsdl-org/SDL_mixer/releases), [SDL_ttf](https://github.com/libsdl-org/SDL_ttf/releases)
 
 
 # Installation


### PR DESCRIPTION
Yo,

I faced some issues when following the windows installation steps when compiling, so I had to add include flags manually:
```
In file included from C:\Users\redacted\go\pkg\mod\github.com\veandco\go-sdl2@v0.4.40\sdl\audio.go:4:
./sdl_wrapper.h:2:18: fatal error: SDL2/SDL.h: No such file or directory
    2 |         #include <SDL2/SDL.h>
      |                  ^~~~
compilation terminated.
```

I found some other people complaining about this error as well and after searching a little bit, I saw that you can add CGO flags from environment variables.

Platform: W11 Enterprise 23H2
Processor	AMD Ryzen 7 PRO 5875U with Radeon Graphics        2.00 GHz
Installed RAM	64,0 GB (62,8 GB usable)
System type	64-bit operating system, x64-based processor




