### PR TITLE
Update README.md to specify SDL2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ NOTE: For the latest versions of SDL2, please use the `master` branch!
 
 # Documentation
 * [GoDoc documentation for go-sdl2](https://godoc.org/github.com/veandco/go-sdl2)
-* [Original SDL2 wiki](https://wiki.libsdl.org)
+* [Original SDL2 wiki](https://wiki.libsdl.org/SDL2)
 
 # Getting Started
 


### PR DESCRIPTION
SDL3 is coming and they've changed the main website to default to SDL3, this is just a small change to fix a little annoyance with the link in the readme