### PR TITLE
README.md: address linter warnings re: unkeyed fields and redundant control flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ func main() {
 			case sdl.QuitEvent: // NOTE: Please use `*sdl.QuitEvent` for `v0.4.x` (current version).
 				println("Quit")
 				running = false
-				break
 			}
 		}
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ func main() {
 	}
 	surface.FillRect(nil, 0)
 
-	rect := sdl.Rect{0, 0, 200, 200}
+	rect := sdl.Rect{X: 0, Y: 0, W: 200, H: 200}
 	colour := sdl.Color{R: 255, G: 0, B: 255, A: 255} // purple
 	pixel := sdl.MapRGBA(surface.Format, colour.R, colour.G, colour.B, colour.A)
 	surface.FillRect(&rect, pixel)


### PR DESCRIPTION
The larger example (in both the `master` as well as `v0.4.x` branches) produces two linter warnings:

* line 24: "github.com/veandco/go-sdl2/sdl.Rect struct literal uses unkeyed fields"
* line 37: "redundant break statementS1023"

This pull request updates line 24 to specify the sdl.Rect fields (`X`, `Y`, `W`, and `H`) and deletes line 37 (removing the redundant/unnecessary `break` statement).

In eliminating the linter warnings, people new to the language or library, and relying on the example for their initial exposure, will have more confidence that they are on the right track.

Thanks for your consideration.